### PR TITLE
[012-진행상황-등록] 진행상황 기초

### DIFF
--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/entities/progress/Progress.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/entities/progress/Progress.java
@@ -1,19 +1,45 @@
 package com.example.checkinrequestMS.HelpAPI.domain.entities.progress;
 
 import com.example.checkinrequestMS.HelpAPI.domain.entities.help.Help;
+import com.example.checkinrequestMS.HelpAPI.web.form.progress.ProgressRegisterForm;
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Progress {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "progress_id", nullable = false)
     private Long id;
 
-    @OneToOne(mappedBy = "progress")
+    @OneToOne
+    @JoinColumn(name = "help_id")
     private Help help;
-    //todo: 이 엔티티는 다음 커밋때 완성 하려고 합니다.
 
+    private Long helperId;
+
+    private String picturePath;
+
+    private boolean isCompleted;
+
+    public void setHelp(Help help) {
+        this.help = help;
+    }
+
+    public static Progress from(ProgressRegisterForm form) {
+        //fixme: 이렇게 ID만 가지고 생성해도 괜찮은 걸까요?
+        //       이후에 서비스에서 조회해서 바꿔치기 하려고 합니다.
+        Help help = Help.createEmptyHelpWithOnlyId(form.getHelpId());
+
+        return Progress.builder()
+                .helperId(form.getHelperId())
+                .help(help)
+                .build();
+    }
 
 
 }

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/exceptions/ProgressErrorCode.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/exceptions/ProgressErrorCode.java
@@ -1,0 +1,12 @@
+package com.example.checkinrequestMS.HelpAPI.domain.exceptions;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProgressErrorCode {
+    ;
+
+    private final String detail;
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/service/progress/ProgressCRUDService.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/service/progress/ProgressCRUDService.java
@@ -1,0 +1,37 @@
+package com.example.checkinrequestMS.HelpAPI.domain.service.progress;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.Help;
+import com.example.checkinrequestMS.HelpAPI.domain.entities.progress.Progress;
+import com.example.checkinrequestMS.HelpAPI.domain.exceptions.HelpException;
+import com.example.checkinrequestMS.HelpAPI.infra.db.help.HelpJPARepository;
+import com.example.checkinrequestMS.HelpAPI.infra.db.progress.ProgressJPARepository;
+import com.example.checkinrequestMS.HelpAPI.infra.exceptions.JPAException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.checkinrequestMS.HelpAPI.domain.exceptions.HelpErrorCode.NO_HELP_INFO;
+import static com.example.checkinrequestMS.HelpAPI.infra.exceptions.JPAErrorCode.ERROR_SAVING;
+
+@Service
+@RequiredArgsConstructor
+public class ProgressCRUDService {
+
+    private final ProgressJPARepository progressJPARepository;
+    private final HelpJPARepository helpJPARepository;
+
+    @Transactional
+    public Progress registerProgress(Progress progress) {
+        Help help = helpJPARepository.findById(progress.getHelp().getId()).orElseThrow(
+                () -> new HelpException(NO_HELP_INFO)
+        );
+        progress.setHelp(help);
+
+        try{
+            return progressJPARepository.save(progress);
+        }catch (Exception e) {
+            throw new JPAException(ERROR_SAVING);
+        }
+    }
+
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/progress/ProgressJPARepository.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/progress/ProgressJPARepository.java
@@ -1,0 +1,7 @@
+package com.example.checkinrequestMS.HelpAPI.infra.db.progress;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.progress.Progress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProgressJPARepository extends JpaRepository<Progress, Long> {
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/controller/progress/ProgressCRUDController.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/controller/progress/ProgressCRUDController.java
@@ -1,0 +1,24 @@
+package com.example.checkinrequestMS.HelpAPI.web.controller.progress;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.progress.Progress;
+import com.example.checkinrequestMS.HelpAPI.domain.service.progress.ProgressCRUDService;
+import com.example.checkinrequestMS.HelpAPI.web.dto.progress.ProgressDTO;
+import com.example.checkinrequestMS.HelpAPI.web.form.progress.ProgressRegisterForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/help/progress")
+@RequiredArgsConstructor
+public class ProgressCRUDController {
+
+    private final ProgressCRUDService progressRegisterService;
+
+    @PostMapping
+    public ResponseEntity<ProgressDTO> selectProgress(@Validated @RequestBody ProgressRegisterForm form) {
+        return ResponseEntity.ok(ProgressDTO.from(progressRegisterService.registerProgress(Progress.from(form))));
+    }
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/dto/progress/ProgressDTO.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/dto/progress/ProgressDTO.java
@@ -1,0 +1,30 @@
+package com.example.checkinrequestMS.HelpAPI.web.dto.progress;
+
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.progress.Progress;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public class ProgressDTO {
+
+    // fixme: Progress 엔티티에서는 Help 엔티티를 참조하고 있지만
+    //  ProgressDTO가 조회 되는 경우는 보통 Help 관련 엔티티를 조회할때 같이 조회 될것 같고
+    //  단독으로 조회 되더라도 Help자체에 대한 정보라기 보다 진행 상황에 관한 정보가 필요할것 같아서
+    //  (Help 에서 상태를 새로고침등)
+    //  Help 관련 정보는 ProgressDTO에서 뺏는데 이렇게 선택적으로 사용해도 괜찮을까요?
+    private Long id;
+    private Long helperId;
+    private String picturePath;
+    private boolean isCompleted;
+
+    public static ProgressDTO from(Progress progress) {
+        return ProgressDTO.builder()
+                .id(progress.getId())
+                .helperId(progress.getHelperId())
+                .picturePath(progress.getPicturePath())
+                .isCompleted(progress.isCompleted())
+                .build();
+    }
+
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/form/progress/ProgressRegisterForm.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/form/progress/ProgressRegisterForm.java
@@ -1,0 +1,14 @@
+package com.example.checkinrequestMS.HelpAPI.web.form.progress;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ProgressRegisterForm {
+
+    @NotNull
+    private Long helpId;
+
+    @NotNull
+    private Long helperId;
+}

--- a/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/domain/service/progress/ProgressCRUDServiceTest.java
+++ b/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/domain/service/progress/ProgressCRUDServiceTest.java
@@ -1,0 +1,72 @@
+package com.example.checkinrequestMS.HelpAPI.domain.service.progress;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.Help;
+import com.example.checkinrequestMS.HelpAPI.domain.entities.progress.Progress;
+import com.example.checkinrequestMS.HelpAPI.domain.exceptions.HelpException;
+import com.example.checkinrequestMS.HelpAPI.infra.db.help.HelpJPARepository;
+import com.example.checkinrequestMS.HelpAPI.infra.db.progress.ProgressJPARepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Optional;
+
+import static com.example.checkinrequestMS.HelpAPI.domain.exceptions.HelpErrorCode.NO_HELP_INFO;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProgressCRUDServiceTest {
+
+    @InjectMocks
+    private ProgressCRUDService sut;
+
+    @Mock
+    private ProgressJPARepository progressJPARepository;
+
+    @Mock
+    private HelpJPARepository helpJPARepository;
+
+    @Test
+    @DisplayName("진행 정보 등록 성공")
+    void registerProgress() {
+        //given
+        Progress progress = spy(Progress.class);
+        Help help = mock(Help.class);
+        given(progress.getHelp()).willReturn(help);
+        given(help.getId()).willReturn(1L);
+        given(helpJPARepository.findById(progress.getHelp().getId())).willReturn(Optional.of(help));
+
+        //when
+        Progress returned = sut.registerProgress(progress);
+
+        //then
+        verify(progress, times(1)).setHelp(help);
+        verify(progressJPARepository, times(1)).save(progress);
+    }
+
+    @Test
+    @DisplayName("도움 정보가 존재하지 않을 때 HelpException 발생")
+    void registerProgress_NO_HELP_Exception() {
+        //given
+        Progress progress = spy(Progress.class);
+        Help help = mock(Help.class);
+        given(progress.getHelp()).willReturn(help);
+        given(help.getId()).willReturn(1L);
+        given(helpJPARepository.findById(progress.getHelp().getId())).willReturn(Optional.empty());
+
+        //when
+        HelpException exception = assertThrows(HelpException.class, () -> sut.registerProgress(progress));
+
+        //then
+        assertEquals("도움 정보가 존재하지 않습니다.", NO_HELP_INFO.getDetail());
+
+    }
+
+}


### PR DESCRIPTION
# 수정사항
- 체크인등의 "Help"엔티티를 다른 유저가 수락했을때 진행되는 "Progress"엔티티의 등록과정 입니다.

<이후 변경사항>
Help와 Progress가 서로 일대일 단방향으로 양쪽에서 되어 있었는데 Progress가 주인인 일대일 양방향 관계로 바꾸었습니다. Help에서 처음에 Progress 는 널이고 이후에 누군가 요청을 받으면 Progress가 생성되며 등록되고 진행상황도 Progress에서 관리하기에 Progress를 주인으로 만들었습니다.