### PR TITLE
[015-기타요청-등록-조회] 기타요청 등록 및 조회

### DIFF
--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/entities/help/child/Etc.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/entities/help/child/Etc.java
@@ -1,11 +1,43 @@
 package com.example.checkinrequestMS.HelpAPI.domain.entities.help.child;
 
 import com.example.checkinrequestMS.HelpAPI.domain.entities.help.Help;
+import com.example.checkinrequestMS.HelpAPI.domain.entities.progress.Progress;
+import com.example.checkinrequestMS.HelpAPI.web.form.help.etc.EtcRegisterForm;
+import com.example.checkinrequestMS.HelpAPI.web.form.help.lineUp.LineUpRegisterForm;
+import com.example.checkinrequestMS.PlaceAPI.domain.Place;
 import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
+@SuperBuilder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Etc extends Help {
 
-    private String content;
+    private String contents;
+
+    public void setPlaceWithFullInfo(Place place){
+        this.place = place;
+    }
+    public void setProgress(Progress progress){
+        this.progress = progress;
+    }
+
+    public static Etc from(EtcRegisterForm form){
+        Place place = Place.createEmptyPlaceWithOnlyId(form.getPlaceId());
+
+        return Etc.builder()
+                .title(form.getTitle())
+                .memberId(form.getMemberId())
+                .start(form.getStart())
+                .end(form.getStart().plusHours(form.getOption())) // 체크인은 30분 단위, 나머지는 시간 단위.
+                .place(place)
+                .reward(form.getReward())
+                .contents(form.getContents())
+                .build();
+    }
 
 }

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/service/etc/EtcCRUDService.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/service/etc/EtcCRUDService.java
@@ -1,0 +1,34 @@
+package com.example.checkinrequestMS.HelpAPI.domain.service.etc;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.Etc;
+import com.example.checkinrequestMS.HelpAPI.infra.db.help.EtcJPARepository;
+import com.example.checkinrequestMS.HelpAPI.infra.exceptions.JPAException;
+import com.example.checkinrequestMS.PlaceAPI.domain.Place;
+import com.example.checkinrequestMS.PlaceAPI.domain.exceptions.place.PlaceException;
+import com.example.checkinrequestMS.PlaceAPI.infra.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.checkinrequestMS.HelpAPI.infra.exceptions.JPAErrorCode.ERROR_SAVING;
+import static com.example.checkinrequestMS.PlaceAPI.domain.exceptions.place.PlaceErrorCode.NO_PLACE_INFO;
+
+@Service
+@RequiredArgsConstructor
+public class EtcCRUDService {
+    private final EtcJPARepository etcJPARepository;
+    private final PlaceRepository placeRepository;
+
+    @Transactional
+    public void registerEtc(Etc etc) {
+        Place place = placeRepository.findById(etc.getPlace().getId())
+                .orElseThrow(() -> new PlaceException(NO_PLACE_INFO));
+        etc.setPlaceWithFullInfo(place);
+
+        try {
+            etcJPARepository.save(etc);
+        } catch (Exception e) {
+            throw new JPAException(ERROR_SAVING);
+        }
+    }
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/service/etc/EtcSelectService.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/service/etc/EtcSelectService.java
@@ -1,0 +1,26 @@
+package com.example.checkinrequestMS.HelpAPI.domain.service.etc;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.Etc;
+import com.example.checkinrequestMS.HelpAPI.domain.exceptions.HelpErrorCode;
+import com.example.checkinrequestMS.HelpAPI.domain.exceptions.HelpException;
+import com.example.checkinrequestMS.HelpAPI.infra.db.help.EtcJPARepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.checkinrequestMS.HelpAPI.domain.exceptions.HelpErrorCode.No_ETC_INFO;
+
+@Service
+@RequiredArgsConstructor
+public class EtcSelectService {
+
+    private final EtcJPARepository etcJPARepository;
+
+    @Transactional
+    public Etc selectEtc(Long id) {
+        return etcJPARepository.findById(id).orElseThrow(
+                () -> new HelpException(No_ETC_INFO)
+        );
+
+    }
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/help/EtcJPARepository.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/help/EtcJPARepository.java
@@ -1,0 +1,7 @@
+package com.example.checkinrequestMS.HelpAPI.infra.db.help;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.Etc;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EtcJPARepository extends JpaRepository<Etc, Long> {
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/etc/EtcCRUDController.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/etc/EtcCRUDController.java
@@ -1,0 +1,28 @@
+package com.example.checkinrequestMS.HelpAPI.web.controller.help.etc;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.Etc;
+import com.example.checkinrequestMS.HelpAPI.domain.service.etc.EtcCRUDService;
+import com.example.checkinrequestMS.HelpAPI.web.form.help.etc.EtcRegisterForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/help/etc")
+@RequiredArgsConstructor
+public class EtcCRUDController {
+
+    private final EtcCRUDService etcCRUDService;
+
+    private static final String ETC_SUCCESS = "기타 요청 등록 성공";
+
+    @PostMapping
+    public ResponseEntity<String> registerEtc(@Validated @RequestBody EtcRegisterForm form) {
+        etcCRUDService.registerEtc(Etc.from(form));
+        return ResponseEntity.ok(ETC_SUCCESS);
+    }
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/etc/EtcSelectController.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/etc/EtcSelectController.java
@@ -1,0 +1,26 @@
+package com.example.checkinrequestMS.HelpAPI.web.controller.help.etc;
+
+import com.example.checkinrequestMS.HelpAPI.domain.service.etc.EtcSelectService;
+import com.example.checkinrequestMS.HelpAPI.web.dto.help.etc.EtcDTO;
+import com.example.checkinrequestMS.HelpAPI.web.dto.help.lineUp.LineUpDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/help/etc")
+@RequiredArgsConstructor
+public class EtcSelectController {
+
+    private final EtcSelectService etcSelectService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<EtcDTO> selectLineUp(@PathVariable Long id) {
+        return ResponseEntity.ok(EtcDTO.from(etcSelectService.selectEtc(id)));
+    }
+
+
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/dto/help/etc/EtcDTO.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/dto/help/etc/EtcDTO.java
@@ -1,0 +1,42 @@
+package com.example.checkinrequestMS.HelpAPI.web.dto.help.etc;
+
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.Etc;
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.LineUp;
+import com.example.checkinrequestMS.HelpAPI.web.dto.progress.ProgressDTO;
+import com.example.checkinrequestMS.PlaceAPI.web.dto.PlaceDTO;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class EtcDTO {
+    private Long id;
+    private Long memberId;
+    private String title;
+    private PlaceDTO place;
+    private LocalDateTime start;
+    private LocalDateTime end;
+    private String contents;
+    private ProgressDTO progress;
+    private Long reward;
+
+    public static EtcDTO from(Etc etc) {
+
+        return EtcDTO.builder()
+                .id(etc.getId())
+                .memberId(etc.getMemberId())
+                .title(etc.getTitle())
+                .place(PlaceDTO.from(etc.getPlace()))
+                .start(etc.getStart())
+                .end(etc.getEnd())
+                .contents(etc.getContents())
+                .progress(ProgressDTO.from(etc.getProgress()))
+                .reward(etc.getReward())
+                .build();
+
+    }
+}

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/form/help/etc/EtcRegisterForm.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/form/help/etc/EtcRegisterForm.java
@@ -1,0 +1,26 @@
+package com.example.checkinrequestMS.HelpAPI.web.form.help.etc;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class EtcRegisterForm {
+    @NotNull
+    private Long memberId;
+    @NotNull
+    private Long placeId;;
+    @NotNull
+    private String title;
+    @NotNull
+    private String contents; //todo: Longtext(?)
+    @NotNull
+    private LocalDateTime start;
+    @NotNull
+    private int option;
+    @NotNull
+    private Long reward;
+
+
+}

--- a/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/domain/service/etc/EtcCRUDServiceTest.java
+++ b/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/domain/service/etc/EtcCRUDServiceTest.java
@@ -1,0 +1,52 @@
+package com.example.checkinrequestMS.HelpAPI.domain.service.etc;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.Etc;
+import com.example.checkinrequestMS.HelpAPI.infra.db.help.EtcJPARepository;
+import com.example.checkinrequestMS.PlaceAPI.domain.Place;
+import com.example.checkinrequestMS.PlaceAPI.infra.PlaceRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EtcCRUDServiceTest {
+
+    @InjectMocks
+    private EtcCRUDService sut;
+
+    @Mock
+    private EtcJPARepository etcJPARepository;
+
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @Test
+    void registerEtc() {
+        //given
+        Place emptyPlaceWithOnlyId = mock(Place.class);
+        given(emptyPlaceWithOnlyId.getId()).willReturn(1L);
+
+        Etc etc = spy(Etc.class);
+        given(etc.getPlace()).willReturn(emptyPlaceWithOnlyId);
+
+        Place placeWithFullInfo = mock(Place.class);
+        given(placeRepository.findById(1L)).willReturn(Optional.of(placeWithFullInfo));
+
+        //when
+        sut.registerEtc(etc);
+
+        //then
+        verify(placeRepository, times(1)).findById(1L);
+        verify(etc, times(1)).setPlaceWithFullInfo(placeWithFullInfo);
+        verify(etcJPARepository, times(1)).save(etc);
+
+    }
+}

--- a/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/domain/service/etc/EtcCRUDServiceTest_Integrated.java
+++ b/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/domain/service/etc/EtcCRUDServiceTest_Integrated.java
@@ -1,0 +1,38 @@
+package com.example.checkinrequestMS.HelpAPI.domain.service.etc;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.Etc;
+import com.example.checkinrequestMS.PlaceAPI.domain.Place;
+import com.example.checkinrequestMS.PlaceAPI.infra.PlaceRepository;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+@SpringBootTest
+@Disabled
+public class EtcCRUDServiceTest_Integrated {
+
+    @Autowired
+    private EtcCRUDService sut;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Test
+    void registerEtc() {
+        //given
+        Place place = Place.createEmptyPlaceWithOnlyId(1L);
+        placeRepository.save(place);
+        //Place Name API에서 바로 저장해서 지금은 null
+        //Id 는 auto increment로 되어있어서 바뀜.
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneHourLater = now.plusHours(1);
+        Etc etcToRegister = Etc.builder().memberId(1L).title("title").place(place).start(now).end(oneHourLater).reward(100L).build();
+
+        //when
+        sut.registerEtc(etcToRegister);
+    }
+}

--- a/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/domain/service/etc/EtcSelectServiceTest.java
+++ b/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/domain/service/etc/EtcSelectServiceTest.java
@@ -1,0 +1,36 @@
+package com.example.checkinrequestMS.HelpAPI.domain.service.etc;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.Etc;
+import com.example.checkinrequestMS.HelpAPI.infra.db.help.EtcJPARepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EtcSelectServiceTest {
+
+    @InjectMocks
+    private EtcSelectService sut;
+
+    @Mock
+    private EtcJPARepository etcJPARepository;
+
+    @Test
+    void selectEtc() {
+        //given
+        Long id = 1L;
+        given(etcJPARepository.findById(id)).willReturn(java.util.Optional.of(mock(Etc.class)));
+
+        //when
+        Etc returned = sut.selectEtc(id);
+
+        //then
+        verify(etcJPARepository, times(1)).findById(1L);
+    }
+}

--- a/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/etc/EtcCRUDControllerTest.java
+++ b/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/etc/EtcCRUDControllerTest.java
@@ -1,0 +1,62 @@
+package com.example.checkinrequestMS.HelpAPI.web.controller.help.etc;
+
+import com.example.checkinrequestMS.HelpAPI.domain.service.etc.EtcCRUDService;
+import com.example.checkinrequestMS.HelpAPI.web.form.help.etc.EtcRegisterForm;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(EtcCRUDController.class)
+class EtcCRUDControllerTest {
+
+    @MockBean
+    private EtcCRUDService etcCRUDService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("기타 요청 등록 성공")
+    void registerEtc() throws Exception {
+        //given
+        //전부 Validator 거치는 조건들 입니다.
+        EtcRegisterForm form = mock();
+        given(form.getMemberId()).willReturn(1L);
+        given(form.getPlaceId()).willReturn(1L);
+        given(form.getStart()).willReturn(LocalDateTime.now());
+        given(form.getOption()).willReturn(1);
+        given(form.getReward()).willReturn(1000L);
+        given(form.getTitle()).willReturn("title");
+        given(form.getContents()).willReturn("contents");
+
+        //when
+        ResultActions result = mockMvc.perform(post("/help/etc")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(form)));
+
+        //then
+        result.andExpect(status().isOk())
+              .andExpect(jsonPath("$").value("기타 요청 등록 성공"));
+
+    }
+}

--- a/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/etc/EtcSelectControllerTest.java
+++ b/check-in-request-MS/src/test/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/etc/EtcSelectControllerTest.java
@@ -1,0 +1,68 @@
+package com.example.checkinrequestMS.HelpAPI.web.controller.help.etc;
+
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.Etc;
+import com.example.checkinrequestMS.HelpAPI.domain.entities.help.child.LineUp;
+import com.example.checkinrequestMS.HelpAPI.domain.entities.progress.Progress;
+import com.example.checkinrequestMS.HelpAPI.domain.service.etc.EtcSelectService;
+import com.example.checkinrequestMS.HelpAPI.web.controller.help.lineUp.LineUpSelectController;
+import com.example.checkinrequestMS.HelpAPI.web.dto.help.etc.EtcDTO;
+import com.example.checkinrequestMS.HelpAPI.web.dto.help.lineUp.LineUpDTO;
+import com.example.checkinrequestMS.PlaceAPI.domain.Place;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(EtcSelectController.class)
+class EtcSelectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EtcSelectService etcSelectService;
+
+    @Test
+    void selectEtc() throws Exception {
+        //given
+        Long etcId = 1L;
+        try(MockedStatic<EtcDTO> mockStaticEtcDTO = mockStatic(EtcDTO.class)){
+            Etc etc = mock(Etc.class);
+            given(etc.getId()).willReturn(etcId);
+
+            Place place = mock(Place.class);
+            given(place.getId()).willReturn(1L);
+            given(etc.getPlace()).willReturn(place);
+
+            Progress progress = mock(Progress.class);
+            given(progress.getId()).willReturn(1L);
+            given(etc.getProgress()).willReturn(progress);
+
+            when(etcSelectService.selectEtc(etcId)).thenReturn(etc);
+            when(EtcDTO.from(etc)).thenReturn(mock(EtcDTO.class));
+        }
+
+        // Perform the GET request and verify the response
+        ResultActions result = mockMvc.perform(get("/help/etc/" + etcId));
+
+        // Verify that the service method was called
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.place.id").value(1L))
+                .andExpect(jsonPath("$.progress.id").value(1L));
+
+        verify(etcSelectService, times(1)).selectEtc(etcId);
+
+    }
+
+
+}


### PR DESCRIPTION
# 변경사항

- Etc 엔터티에 대한 등록 및 조회 코드입니다.

이번에는 fixme에 못 적었지만 대부분 체크인과 같은 코드이지만 아래 2가지가 다릅니다.
1. CheckIn 과 LineUp은 요청의 이름을 자동으로 만들지만 Etc는 사용자의 입력을 받아서 사용합니다.
2. 두 요청과 다르게 상세 내역(Contents)를 쓸 수 있습니다. 