### PR TITLE
[031-Member-MS-Member-Id-변경] Long에서 String으로 변경하여 UUID 사용

### DIFF
--- a/member-context/src/main/java/com/membercontext/memberAPI/application/repository/MemberRepository.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/repository/MemberRepository.java
@@ -5,9 +5,9 @@ import com.membercontext.memberAPI.domain.entity.member.Member;
 public interface MemberRepository {
     public Member findByEmail(String email);
 
-    public Member findById(Long id);
+    public Member findById(String id);
 
-    public void delete(Long id);
+    public void delete(String id);
 
     public void save(Member member);
 

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberInfo/MemberInfoService.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberInfo/MemberInfoService.java
@@ -4,5 +4,5 @@ import com.membercontext.memberAPI.domain.entity.member.Member;
 
 public interface MemberInfoService {
 
-    public Member getMemberInfo(Long id);
+    public Member getMemberInfo(String id);
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberInfo/MemberInfoServiceImpl.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberInfo/MemberInfoServiceImpl.java
@@ -7,12 +7,12 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class MemberInfoServiceImpl implements MemberInfoService{
+public class MemberInfoServiceImpl implements MemberInfoService {
 
     private final MemberRepository memberRepository;
 
     @Override
-    public Member getMemberInfo(Long id) {
+    public Member getMemberInfo(String id) {
         return memberRepository.findById(id);
     }
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/SignUpSerivces/Impl/SignUpServiceImpl.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/SignUpSerivces/Impl/SignUpServiceImpl.java
@@ -37,7 +37,7 @@ public class SignUpServiceImpl implements SignUpService {
 
     @Override
     @Transactional
-    public String delete(Long id) {
+    public String delete(String id) {
         final String deleteSuccessMessage = "회원 삭제 성공";
 
         memberRepository.delete(id);

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/SignUpSerivces/SignUpService.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/SignUpSerivces/SignUpService.java
@@ -8,5 +8,5 @@ public interface SignUpService {
 
     public Member update(Member updatingMember);
 
-    public String delete(Long id);
+    public String delete(String id);
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/testFixture/MemberTest.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/testFixture/MemberTest.java
@@ -1,9 +1,6 @@
 package com.membercontext.memberAPI.domain.entity.member.testFixture;
 
 import com.membercontext.memberAPI.domain.entity.member.Member;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
 
 
 public class MemberTest extends Member {
@@ -16,11 +13,12 @@ public class MemberTest extends Member {
                 .name(name)
                 .phone(phone)
                 .location(location)
-                .isLocationServiceEnabled(isLocationServiceEnabled)
+                .locationServiceEnabled(isLocationServiceEnabled)
                 .point(point)
                 .build();
     }
-    public static Member createUpdatingMember(Long id, String email, String password, String name, String phone, String location, Boolean isLocationServiceEnabled, Long point) {
+
+    public static Member createUpdatingMember(String id, String email, String password, String name, String phone, String location, Boolean isLocationServiceEnabled, Long point) {
         return Member.builder()
                 .id(id)
                 .email(email)
@@ -28,7 +26,7 @@ public class MemberTest extends Member {
                 .name(name)
                 .phone(phone)
                 .location(location)
-                .isLocationServiceEnabled(isLocationServiceEnabled)
+                .locationServiceEnabled(isLocationServiceEnabled)
                 .point(point)
                 .build();
     }

--- a/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepository.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepository.java
@@ -23,13 +23,13 @@ public class MemberJPARepository implements MemberRepository {
     }
 
     @Override
-    public Member findById(Long id) {
+    public Member findById(String id) {
         return memberSpringJPARepository.findById(id)
                 .orElseThrow(() -> new MemberException(NOT_EXITING_USER));
     }
 
     @Override
-    public void delete(Long id) {
+    public void delete(String id) {
         Member member = memberSpringJPARepository.findById(id)
                 .orElseThrow(() -> new MemberException(NOT_EXITING_USER));
         memberSpringJPARepository.delete(member);

--- a/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberSpringJPARepository.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberSpringJPARepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberSpringJPARepository extends JpaRepository<Member, Long> {
+public interface MemberSpringJPARepository extends JpaRepository<Member, String> {
     Optional<Member> findByEmail(String email);
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/MemberInfoController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/MemberInfoController.java
@@ -17,7 +17,7 @@ public class MemberInfoController {
     private final MemberInfoService memberInfoService;
 
     @PostMapping
-    public ResponseEntity<MemberDto> getMemberInfo(@RequestParam Long id) {
+    public ResponseEntity<MemberDto> getMemberInfo(@RequestParam String id) {
         return ResponseEntity.ok(MemberDto.from(memberInfoService.getMemberInfo(id)));
     }
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/form/UpdateForm.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/form/UpdateForm.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class UpdateForm {
 
     @NotNull(message = "회원번호를 입력해주세요")
-    private Long id;
+    private String id;
 
     @Email(message = "이메일 형식에 맞게 입력해주세요")
     @NotBlank(message = "이메일을 입력해주세요")
@@ -32,7 +32,6 @@ public class UpdateForm {
 
     @NotNull(message = "현재 포인트를 입력해주세요")
     Long point;
-
 
 
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/dto/MemberDto.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/dto/MemberDto.java
@@ -10,7 +10,7 @@ import lombok.*;
 
 public class MemberDto {
 
-    private Long id;
+    private String id;
 
     private String email;
 
@@ -27,7 +27,7 @@ public class MemberDto {
     private Long point;
 
 
-    public static MemberDto from(Member member){
+    public static MemberDto from(Member member) {
         return MemberDto.builder()
                 .id(member.getId())
                 .email(member.getEmail())
@@ -35,11 +35,10 @@ public class MemberDto {
                 .name(member.getName())
                 .phone(member.getPhone())
                 .location(member.getLocation())
-                .isLocationServiceEnabled(member.getIsLocationServiceEnabled())
+                .isLocationServiceEnabled(member.isLocationServiceEnabled())
                 .point(member.getPoint())
                 .build();
     }
-
 
 
 }

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/service/MemberInfoServiceImplTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/service/MemberInfoServiceImplTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,7 +33,7 @@ class MemberInfoServiceImplTest {
     void getMemberInfo() {
         //given
         Member memberToSearch = memberTestFixture.create_Mock();
-        when(memberRepository.findById(anyLong())).thenReturn(memberToSearch);
+        when(memberRepository.findById(anyString())).thenReturn(memberToSearch);
 
         //when
         Member memberReturned = memberInfoService.getMemberInfo(memberToSearch.getId());
@@ -44,7 +45,7 @@ class MemberInfoServiceImplTest {
         assertEquals(memberToSearch.getName(), memberReturned.getName());
         assertEquals(memberToSearch.getPhone(), memberReturned.getPhone());
         assertEquals(memberToSearch.getLocation(), memberReturned.getLocation());
-        assertEquals(memberToSearch.getIsLocationServiceEnabled(), memberReturned.getIsLocationServiceEnabled());
+        assertEquals(memberToSearch.isLocationServiceEnabled(), memberReturned.isLocationServiceEnabled());
         assertEquals(memberToSearch.getPoint(), memberReturned.getPoint());
     }
 }

--- a/member-context/src/test/java/com/membercontext/memberAPI/domain/fixture/MemberTestFixture.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/domain/fixture/MemberTestFixture.java
@@ -8,24 +8,24 @@ import static org.mockito.Mockito.when;
 
 public class MemberTestFixture {
 
-    public Member create_Mock(){
+    public Member create_Mock() {
         Member member = mock(Member.class);
-        when(member.getId()).thenReturn(1L);
+        when(member.getId()).thenReturn("MEMBER_ID");
         when(member.getEmail()).thenReturn("tester@test.com");
         when(member.getPassword()).thenReturn("password");
         when(member.getName()).thenReturn("tester");
         when(member.getPhone()).thenReturn("010-1234-5678");
         when(member.getLocation()).thenReturn("서울시 강남구");
-        when(member.getIsLocationServiceEnabled()).thenReturn(true);
+        when(member.isLocationServiceEnabled()).thenReturn(true);
         when(member.getPoint()).thenReturn(1000L);
 
         return member;
     }
 
-    public Member from_Mock(UpdateForm form){
+    public Member from_Mock(UpdateForm form) {
         Member member = mock(Member.class);
 
-        Long id = form.getId();
+        String id = form.getId();
         String email = form.getEmail();
         String password = form.getPassword();
         String name = form.getName();
@@ -40,7 +40,7 @@ public class MemberTestFixture {
         when(member.getName()).thenReturn(name);
         when(member.getPhone()).thenReturn(phone);
         when(member.getLocation()).thenReturn(location);
-        when(member.getIsLocationServiceEnabled()).thenReturn(isLocationServiceEnabled);
+        when(member.isLocationServiceEnabled()).thenReturn(isLocationServiceEnabled);
         when(member.getPoint()).thenReturn(point);
 
         return member;

--- a/member-context/src/test/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepositoryTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 
 import java.util.Optional;
+import java.util.UUID;
 
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -44,6 +45,7 @@ class MemberJPARepositoryTest {
         //then
         verify(memberSpringJPARepository).findByEmail(member.getEmail());
     }
+
     @Test
     @DisplayName("이메일로 조회 - 존재하지 않는 회원.")
     void findByEmail_NOT_EXISTING_MEMBER() {
@@ -56,6 +58,7 @@ class MemberJPARepositoryTest {
         //then
         assertThrows(MemberException.class, () -> sut.findByEmail(member.getEmail()));
     }
+
     @Test
     @DisplayName("회원 ID로 조회 - 성공.")
     void findById() {
@@ -69,6 +72,7 @@ class MemberJPARepositoryTest {
         //then
         verify(memberSpringJPARepository).findById(member.getId());
     }
+
     @Test
     @DisplayName("회원 ID로 조회 - 존재하지 않는 회원.")
     void findById_NOT_EXISTING_MEMBER() {
@@ -81,18 +85,20 @@ class MemberJPARepositoryTest {
         //then
         assertThrows(MemberException.class, () -> sut.findById(member.getId()));
     }
+
     @Test
     @DisplayName("회원가입 - 성공.")
     void save() {
-      //given
-      Member member = mock(Member.class);
-      given(memberSpringJPARepository.findByEmail(member.getEmail())).willReturn(Optional.empty());
+        //given
+        Member member = mock(Member.class);
+        given(memberSpringJPARepository.findByEmail(member.getEmail())).willReturn(Optional.empty());
 
-      sut.save(member);
+        sut.save(member);
 
-      verify(memberSpringJPARepository).save(member);
+        verify(memberSpringJPARepository).save(member);
 
     }
+
     @Test
     @DisplayName("회원가입 - 이미 가입한 회원.")
     void save_ALREADY_REGISTERED_USER_Exception() {
@@ -107,10 +113,11 @@ class MemberJPARepositoryTest {
         //then
         assertThrows(MemberException.class, () -> sut.save(newMember));
     }
+
     @Test
     void delete() {
         //given
-        Long id = 1L;
+        String id = UUID.randomUUID().toString();
         Member member = mock(Member.class);
         given(memberSpringJPARepository.findById(id)).willReturn(Optional.of(member));
 
@@ -120,13 +127,15 @@ class MemberJPARepositoryTest {
         //then
         verify(memberSpringJPARepository).delete(member);
     }
+
     @Test
     @DisplayName("회원 삭제 - 존재하지 않는 회원.")
     void delete_NOT_EXISTING_USER_Exception() {
 
         //given
+        String id = "NOT_EXIST";
         Member registeredMember = mock(Member.class);
-        given(registeredMember.getId()).willReturn(1L);
+        given(registeredMember.getId()).willReturn(id);
         given(memberSpringJPARepository.findById(registeredMember.getId())).willReturn(Optional.empty());
 
         //when
@@ -134,6 +143,7 @@ class MemberJPARepositoryTest {
         //then
         assertThrows(MemberException.class, () -> sut.delete(registeredMember.getId()));
     }
+
     @Test
     void update() {
         //given
@@ -148,13 +158,15 @@ class MemberJPARepositoryTest {
         verify(member).update(updatingMember);
         verify(memberSpringJPARepository).save(member);
     }
+
     @Test
     @DisplayName("회원 수정 - 존재하지 않는 회원.")
     void Update_NOT_EXISTING_USER_Exception() {
 
         //given
+        String id = "NOT_EXIST";
         Member updatingMember = mock(Member.class);
-        given(updatingMember.getId()).willReturn(1L);
+        given(updatingMember.getId()).willReturn(id);
         given(memberSpringJPARepository.findById(updatingMember.getId())).willReturn(Optional.empty());
 
         //when
@@ -162,6 +174,7 @@ class MemberJPARepositoryTest {
         //then
         assertThrows(MemberException.class, () -> sut.update(updatingMember));
     }
+
     @Test
     @DisplayName("회원 수정 - 실패.")
     void Update_FAILED_Exception() {

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/MemberInfoControllerTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/MemberInfoControllerTest.java
@@ -48,6 +48,7 @@ class MemberInfoControllerTest {
     static void setUp() {
         memberDto = mockStatic(MemberDto.class);
     }
+
     @AfterAll
     static void tearDown() {
         memberDto.close();
@@ -63,13 +64,13 @@ class MemberInfoControllerTest {
         MemberDtoTextFixture memberDtoTextFixture = new MemberDtoTextFixture();
         MemberDto expectedDto = memberDtoTextFixture.from_Mock(memberToSearch);
 
-        when(memberInfoService.getMemberInfo(anyLong())).thenReturn(memberToSearch);
+        when(memberInfoService.getMemberInfo(anyString())).thenReturn(memberToSearch);
         when(MemberDto.from(any(Member.class))).thenReturn(expectedDto);
 
         //when
         ResultActions resultActions = mockMvc.perform(post(requestUrl)
-                                        .contentType(MediaType.APPLICATION_JSON)
-                                        .param("id", "1"));
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("id", "1"));
 
         //then
         resultActions.andExpect(status().isOk())
@@ -81,8 +82,9 @@ class MemberInfoControllerTest {
                 .andExpect(jsonPath("$.location").value(expectedDto.getLocation()))
                 .andExpect(jsonPath("$.isLocationServiceEnabled").value(expectedDto.getIsLocationServiceEnabled()))
                 .andExpect(jsonPath("$.point").value(expectedDto.getPoint()));
-        verify(memberInfoService, times(1)).getMemberInfo(anyLong());
+        verify(memberInfoService, times(1)).getMemberInfo(anyString());
     }
+
     @Test
     @DisplayName("아이디가 존재하지 않음.")
     void getMemberInfo_NoId() throws Exception {
@@ -90,11 +92,11 @@ class MemberInfoControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(post(requestUrl)
-                                        .param("id", "notId")
-                                        .contentType(MediaType.APPLICATION_JSON));
+                .param("id", "notId")
+                .contentType(MediaType.APPLICATION_JSON));
 
         //then
         resultActions.andExpect(status().isBadRequest());
-        verify(memberInfoService, never()).getMemberInfo(anyLong());
+        verify(memberInfoService, never()).getMemberInfo(anyString());
     }
 }

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/SignUpControllerTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/SignUpControllerTest.java
@@ -54,6 +54,7 @@ public class SignUpControllerTest {
         member = mockStatic(Member.class);
         memberDto = mockStatic(MemberDto.class);
     }
+
     @AfterAll
     static void tearDown() {
         member.close();
@@ -104,7 +105,7 @@ public class SignUpControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(form)));
 
-       //then
+        //then
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(expectedDto.getId()))
                 .andExpect(jsonPath("$.email").value(expectedDto.getEmail()))
@@ -126,17 +127,18 @@ public class SignUpControllerTest {
     @DisplayName("회원 삭제 요청 성공.")
     void delete_URL() throws Exception {
         //given
-        when(signUpService.delete(anyLong())).thenReturn("회원 삭제 성공");
+        String id = "ANY_ID";
+        when(signUpService.delete(anyString())).thenReturn("회원 삭제 성공");
 
         //when
         ResultActions resultActions = mockMvc.perform(delete(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .param("id", "1"));
+                .param("id", id));
 
         //then
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$").value("회원 삭제 성공"));
-        verify(signUpService, times(1)).delete(1L);
+        verify(signUpService, times(1)).delete(id);
     }
 
 

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/fixture/MemberDtoTextFixture.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/fixture/MemberDtoTextFixture.java
@@ -9,13 +9,13 @@ import static org.mockito.Mockito.when;
 public class MemberDtoTextFixture {
     public MemberDto from_Mock(Member member) {
 
-        Long id = member.getId();
+        String id = member.getId();
         String email = member.getEmail();
         String password = member.getPassword();
         String name = member.getName();
         String phone = member.getPhone();
         String location = member.getLocation();
-        Boolean isLocationServiceEnabled = member.getIsLocationServiceEnabled();
+        Boolean isLocationServiceEnabled = member.isLocationServiceEnabled();
         Long point = member.getPoint();
 
         MemberDto memberDto = mock(MemberDto.class);

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/fixture/UpdateFormTestFixture.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/fixture/UpdateFormTestFixture.java
@@ -7,10 +7,10 @@ import static org.mockito.Mockito.when;
 
 public class UpdateFormTestFixture {
 
-    public UpdateForm createAllFilledUpdateForm_Mock(){
+    public UpdateForm createAllFilledUpdateForm_Mock() {
         UpdateForm form = mock(UpdateForm.class);
 
-        when(form.getId()).thenReturn(1L);
+        when(form.getId()).thenReturn("UPDATING_ID");
         when(form.getName()).thenReturn("tester");
         when(form.getEmail()).thenReturn("test@test.com");
         when(form.getPassword()).thenReturn("testPassword");


### PR DESCRIPTION
## 변경사항

- MemberId를 기존의 Long을 이용하는 방식에서 UUID로 변경하였습니다.

- 문제
-1. Long이란 숫자값이 보안에 취약하다고 생각해, 이메일을 unique키로 사용하였습니다.
-2. 또한, PK가 있음에도 Member를 찾을 때는 이메일을 기준으로 식별이 되다 결국 식별자로 이메일을 쓰고 있는 것과 같습니다. 그래서 사실상 이메일을 PK로 쓰는게 맞지만 자연키는 변경에 취약합니다.
-3.이는 사실상 Long으로 사용하고 있는 PK가 역할이 없고 또, 식별자로서의 역할을 못하고 있다고 생각했습니다. 
-4. 또한, 로그인때 주는 쿠키에도 암호화된 이메일이 식별자 역할로 들어가 있어 불필요한 암호화화 해독을 계속 거치게 됩니다. 

- 해결
-1. Long으로 쓰고 있는 memberId를 UUID로 변경하여 이를 인조식별자로 사용하려고 합니다. 
-2. 또한, 로그인시에도 암호화된 이메일이 아닌 UUID를 쿠키에 넣어 주는 것으로 변경 하였습니다.
