### PR TITLE
[040-member-테스트-재정비-편의클래스들과-exception로직-변경]

### DIFF
--- a/member-context/src/main/java/com/membercontext/memberAPI/application/exception/ExceptionController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/exception/ExceptionController.java
@@ -2,8 +2,13 @@ package com.membercontext.memberAPI.application.exception;
 
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @RestControllerAdvice
 public class ExceptionController {
@@ -11,7 +16,22 @@ public class ExceptionController {
     @ExceptionHandler({
             MemberException.class
     })
-    public ResponseEntity<ExceptionResponse> memberException(final MemberException e){
-        return ResponseEntity.badRequest().body(new ExceptionResponse(e.getMessage(), e.getMemberErrorCode()));
+    public ResponseEntity<ExceptionResponse<Void>> memberException(final MemberException e) {
+        return ResponseEntity.badRequest().body(new ExceptionResponse<>(e.getMessage()));
+    }
+
+    public static final String MEMBER_INPUT_ERROR = "입력오류";
+
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class
+    })
+    public ResponseEntity<ExceptionResponse<Map<String, String>>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        AtomicInteger i = new AtomicInteger(1);
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error -> {
+            errors.put(String.valueOf(i.getAndIncrement()), error.getDefaultMessage());
+        });
+
+        return ResponseEntity.badRequest().body(new ExceptionResponse<>(MEMBER_INPUT_ERROR, errors));
     }
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/exception/ExceptionResponse.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/exception/ExceptionResponse.java
@@ -1,14 +1,20 @@
 package com.membercontext.memberAPI.application.exception;
 
-import com.membercontext.memberAPI.application.exception.member.MemberErrorCode;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
-@AllArgsConstructor
-public class ExceptionResponse {
-    private String message;
-    private MemberErrorCode memberErrorCode;
+public class ExceptionResponse<T> {
+    private final String message;
+    private T error;
+
+    public ExceptionResponse(String message, T error) {
+        this.message = message;
+        this.error = error;
+    }
+
+    public ExceptionResponse(String message) {
+        this.message = message;
+    }
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/exception/member/MemberException.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/exception/member/MemberException.java
@@ -3,7 +3,7 @@ package com.membercontext.memberAPI.application.exception.member;
 import lombok.Getter;
 
 @Getter
-public class MemberException extends RuntimeException{
+public class MemberException extends RuntimeException {
     private MemberErrorCode memberErrorCode;
 
     public MemberException(MemberErrorCode memberErrorCode) {
@@ -11,3 +11,4 @@ public class MemberException extends RuntimeException{
         this.memberErrorCode = memberErrorCode;
     }
 }
+

--- a/member-context/src/test/java/com/membercontext/common/LogInTestHelper.java
+++ b/member-context/src/test/java/com/membercontext/common/LogInTestHelper.java
@@ -1,0 +1,42 @@
+package com.membercontext.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.membercontext.memberAPI.application.service.LogInService;
+import com.membercontext.memberAPI.domain.entity.member.Member;
+import com.membercontext.memberAPI.web.controller.LogInController;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.UUID;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+public class LogInTestHelper {
+
+    public static MvcResult Login() throws Exception {
+
+        LogInService logInService = mock(LogInService.class);
+        ObjectMapper mapper = new ObjectMapper();
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new LogInController(logInService)).build();
+
+        //given
+        String requestURL = "/log-in";
+        LogInController.LogInRequest form = mock(LogInController.LogInRequest.class);
+
+        Member member = mock(Member.class);
+        given(member.getId()).willReturn(UUID.randomUUID().toString());
+        given(logInService.logIn(form.getEmail(), form.getPassword())).willReturn(member);
+
+        ResultActions resultActions = mockMvc.perform(post(requestURL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(form)));
+
+        return resultActions.andReturn();
+    }
+}

--- a/member-context/src/test/java/com/membercontext/common/UUIDTester.java
+++ b/member-context/src/test/java/com/membercontext/common/UUIDTester.java
@@ -1,0 +1,13 @@
+package com.membercontext.common;
+
+import java.util.regex.Pattern;
+
+public class UUIDTester {
+
+    static Pattern UUID_REGEX =
+            Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+    public static boolean isUUID(String uuid) {
+        return UUID_REGEX.matcher(uuid).matches();
+    }
+}

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/exception/ExceptionControllerTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/exception/ExceptionControllerTest.java
@@ -1,0 +1,82 @@
+package com.membercontext.memberAPI.application.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.membercontext.common.fixture.web.crud.SignUpRequestFixture;
+import com.membercontext.memberAPI.application.exception.member.MemberException;
+import com.membercontext.memberAPI.application.service.SignUpSerivces.SignUpService;
+import com.membercontext.memberAPI.domain.entity.member.Member;
+import com.membercontext.memberAPI.web.controller.SignUpController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.membercontext.memberAPI.application.exception.ExceptionController.MEMBER_INPUT_ERROR;
+import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.ALREADY_REGISTERED_USER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SignUpController.class)
+class ExceptionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @MockBean
+    private SignUpService signUpService;
+
+    @Test
+    @DisplayName("MemberException 발생 예시")
+    void signUp_Failed() throws Exception {
+
+        //given
+        final String requestURL = "/sign-in";
+        SignUpController.SignUpRequest form = SignUpRequestFixture.create();
+        when(signUpService.signUp(any(Member.class))).thenThrow(new MemberException(ALREADY_REGISTERED_USER));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post(requestURL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(form)));
+
+        //then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(ALREADY_REGISTERED_USER.getDeatil()))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("Validation 에러 발생 예시")
+    void Validation_Failed() throws Exception {
+
+        //given
+        final String requestURL = "/sign-in";
+        SignUpController.SignUpRequest form = mock(SignUpController.SignUpRequest.class);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post(requestURL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(form)));
+
+        //then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(MEMBER_INPUT_ERROR))
+                .andExpect(jsonPath("$.error").isNotEmpty())
+                .andDo(print());
+    }
+
+
+}


### PR DESCRIPTION
### 변경사항

- MockMvc로 로그인을 하여 쿠키를 받을 일이 많아 받아오는 테스트용 핼퍼 클래스 제작

- UUID의 포맷 검사를 쉽게 하기 위한 테스트용 핼퍼 클래스 제작

- Exception Controller에서 Exception을 제네릭을 이용하여 다양한 에러코드를 받을 수 있도록 변경.