### PR TITLE
[045-request-response-불변객체]

### DIFF
--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/AlarmController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/AlarmController.java
@@ -28,7 +28,7 @@ public class AlarmController {
     }
 
     @Getter
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
     @Builder(access = AccessLevel.PROTECTED)
     public static class AlarmRequest {
 
@@ -38,16 +38,16 @@ public class AlarmController {
         public static final String ALARM_MESSAGE_NOT_FOUND = "알람 내용이 없습니다.";
 
         @NotNull(message = ALARM_X_NOT_FOUND)
-        private Double x;
+        private final double x;
 
         @NotNull(message = ALARM_Y_NOT_FOUND)
-        private Double y;
+        private final double y;
 
         @NotBlank(message = ALARM_TITLE_NOT_FOUND)
-        private String title;
+        private final String title;
 
         @NotBlank(message = ALARM_MESSAGE_NOT_FOUND)
-        private String message;
+        private final String message;
     }
 
 

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/LogInController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/LogInController.java
@@ -60,7 +60,7 @@ public class LogInController {
     }
 
     @Getter
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
     @Builder(access = AccessLevel.PROTECTED)
     public static class LogInRequest {
 
@@ -68,10 +68,10 @@ public class LogInController {
         public static final String LOG_IN_PASSWORD_VALIDATION_MESSAGE = "비밀번호가 없습니다.";
 
         @NotBlank(message = LOG_IN_EMAIL_VALIDATION_MESSAGE)
-        private String email;
+        private final String email;
 
         @NotBlank(message = LOG_IN_PASSWORD_VALIDATION_MESSAGE)
-        private String password;
+        private final String password;
     }
 
 

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/SignUpController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/SignUpController.java
@@ -50,88 +50,87 @@ public class SignUpController {
     public static final String LOCATION_VALIDATION_MESSAGE = "동을 입력해주세요";
     public static final String LOCATION_SERVICE_VALIDATION_MESSAGE = "위치 서비스 사용 여부를 입력해주세요";
 
-    //fixme: Request와 Response는 final을 붙여서 불변으로 만드는게 좋을것 같은데 어떨까요?
     @Getter
     @Builder(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
     public static class SignUpRequest {
 
         @Email(message = EMAIL_FORMAT_VALIDATION_MESSAGE)
         @NotBlank(message = EMAIL_VALIDATION_MESSAGE)
-        private String email;
+        private final String email;
 
         @NotBlank(message = PASSWORD_VALIDATION_MESSAGE)
-        private String password;
+        private final String password;
 
         @NotBlank(message = NAME_VALIDATION_MESSAGE)
-        private String name;
+        private final String name;
 
         @NotBlank(message = PHONE_VALIDATION_MESSAGE)
-        private String phone;
+        private final String phone;
 
         @NotBlank(message = LOCATION_VALIDATION_MESSAGE)
-        private String address;
+        private final String address;
 
         @NotNull(message = LOCATION_SERVICE_VALIDATION_MESSAGE)
-        private Boolean isLocationServiceEnabled;
+        private final boolean isLocationServiceEnabled;
 
-        private Long point;
+        private final long point;
     }
 
 
     @Getter
     @Builder(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
     public static class UpdateRequest {
 
         public static final String MEMBER_ID_VALIDATION_MESSAGE = "회원번호를 입력해주세요";
         public static final String POINT_UPDATE_VALIDATION_MESSAGE = "현재 포인트를 입력해주세요";
 
         @NotNull(message = MEMBER_ID_VALIDATION_MESSAGE)
-        private String id;
+        private final String id;
 
         @Email(message = EMAIL_FORMAT_VALIDATION_MESSAGE)
         @NotBlank(message = EMAIL_VALIDATION_MESSAGE)
-        private String email;
+        private final String email;
 
         @NotBlank(message = PASSWORD_VALIDATION_MESSAGE)
-        private String password;
+        private final String password;
 
         @NotBlank(message = NAME_VALIDATION_MESSAGE)
-        private String name;
+        private final String name;
 
         @NotBlank(message = PHONE_VALIDATION_MESSAGE)
-        private String phone;
+        private final String phone;
 
         @NotBlank(message = LOCATION_VALIDATION_MESSAGE)
-        private String location;
+        private final String location;
 
         @NotNull(message = LOCATION_SERVICE_VALIDATION_MESSAGE)
-        private Boolean isLocationServiceEnabled;
+        private final boolean isLocationServiceEnabled;
 
         @NotNull(message = POINT_UPDATE_VALIDATION_MESSAGE)
-        private Long point;
+        private final long point;
     }
 
     @Getter
     @Builder(access = AccessLevel.PRIVATE)
     public static class MemberResponse {
 
-        private String id;
+        private final String id;
 
-        private String email;
+        private final String email;
 
-        private String password;
+        private final String password;
 
-        private String name;
+        private final String name;
 
-        private String phone;
+        private final String phone;
 
-        private String address;
+        private final String address;
 
-        private Boolean isLocationServiceEnabled;
+        private final boolean isLocationServiceEnabled;
 
-        private Long point;
+        private final long point;
 
         public static MemberResponse from(Member member) {
             return MemberResponse.builder()

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TrackController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TrackController.java
@@ -44,7 +44,7 @@ public class TrackController {
     }
 
     @Getter
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
     @Builder(access = AccessLevel.PROTECTED)
     public static class TrackRequest {
 

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TrackController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TrackController.java
@@ -1,6 +1,7 @@
 package com.membercontext.memberAPI.web.controller;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.membercontext.memberAPI.application.service.TrackService;
 import com.membercontext.memberAPI.web.controller.dto.DefaultHTTPResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,18 +27,18 @@ public class TrackController {
     public static final String FCM_TOKEN_REGISTERED = "토큰 등록 성공";
 
     @PostMapping("/track")
-    public ResponseEntity<DefaultHTTPResponse<Void>> track(@CookieValue(value = COOKIE_NAME) String cookieValue, HttpServletRequest request, @Validated @RequestBody TrackRequest trackForm) {
+    public ResponseEntity<DefaultHTTPResponse<Void>> track(@CookieValue(value = COOKIE_NAME) String cookieValue, HttpServletRequest request, @Validated @RequestBody TrackRequest trackRequest) {
         String email = (String) request.getSession().getAttribute(cookieValue);
-        trackService.saveCurrentLocation(trackForm, email);
+        trackService.saveCurrentLocation(trackRequest, email);
 
         return ResponseEntity.ok().body(new DefaultHTTPResponse<>(LOCATION_TRACK_ONGOING));
     }
 
     @PostMapping(value = "/token", consumes = "application/json")
-    public ResponseEntity<DefaultHTTPResponse<Void>> token(@CookieValue(value = COOKIE_NAME) String cookieValue, HttpServletRequest request, @Validated @RequestBody FCMTokenRequest fcmTokenForm) {
+    public ResponseEntity<DefaultHTTPResponse<Void>> token(@CookieValue(value = COOKIE_NAME) String cookieValue, HttpServletRequest request, @Validated @RequestBody FCMTokenRequest fcmTokenRequest) {
         String email = (String) request.getSession().getAttribute(cookieValue);
-        System.out.println(fcmTokenForm.getToken());
-        trackService.saveToken(fcmTokenForm.getToken(), email);
+        System.out.println(fcmTokenRequest.getToken());
+        trackService.saveToken(fcmTokenRequest.getToken(), email);
 
         return ResponseEntity.ok().body(new DefaultHTTPResponse<>(FCM_TOKEN_REGISTERED));
     }
@@ -52,26 +53,29 @@ public class TrackController {
         public static final String TRACK_TIMESTAMP_NOT_FOUND = "시간이 없습니다.";
 
         @NotNull(message = TRACK_LATITUDE_NOT_FOUND)
-        private Double latitude;
+        private final double latitude;
 
         @NotNull(message = TRACK_LONGITUDE_NOT_FOUND)
-        private Double longitude;
+        private final double longitude;
 
         @NotNull(message = TRACK_TIMESTAMP_NOT_FOUND)
-        private LocalDateTime timestamp;
+        private final LocalDateTime timestamp;
     }
 
 
     @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @Builder(access = AccessLevel.PROTECTED)
     public static class FCMTokenRequest {
 
         public static final String FCM_TOKEN_NOT_FOUND = "FCM 토큰이 없습니다.";
 
         @NotBlank(message = FCM_TOKEN_NOT_FOUND)
-        private String token;
+        private final String token;
+
+        @JsonCreator
+        public FCMTokenRequest(String token) {
+            this.token = token;
+        }
     }
 
 

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/TrackControllerTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/TrackControllerTest.java
@@ -45,7 +45,7 @@ class TrackControllerTest {
     @Nested
     class Track {
 
-        private final TrackRequest trackForm = TrackRequestFixture.create();
+        private final TrackRequest trackRequest = TrackRequestFixture.create();
 
         @Test
         @DisplayName("로그인 - 위치 추적 시작.")
@@ -62,7 +62,7 @@ class TrackControllerTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .cookie(cookie)
                     .session(session)
-                    .content(mapper.writeValueAsString(trackForm)));
+                    .content(mapper.writeValueAsString(trackRequest)));
 
             //then
             resultActions.andExpect(status().isOk())
@@ -78,7 +78,7 @@ class TrackControllerTest {
             //when
             ResultActions resultActions = mockMvc.perform(post(requestURL)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(mapper.writeValueAsString(trackForm)));
+                    .content(mapper.writeValueAsString(trackRequest)));
 
             //then
             resultActions.andExpect(status().isBadRequest());
@@ -88,7 +88,7 @@ class TrackControllerTest {
     @Nested
     class Token {
 
-        private final FCMTokenRequest fcmTokenForm = FCMTokenRequestFixture.create();
+        private final FCMTokenRequest fcmTokenRequest = FCMTokenRequestFixture.create();
 
         @Test
         @DisplayName("로그인 - 토큰 저장")
@@ -106,7 +106,7 @@ class TrackControllerTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .cookie(cookie)
                     .session(session)
-                    .content(mapper.writeValueAsString(fcmTokenForm)));
+                    .content(mapper.writeValueAsString(fcmTokenRequest)));
 
             //then
             resultActions.andExpect(status().isOk())
@@ -122,7 +122,7 @@ class TrackControllerTest {
             //when
             ResultActions resultActions = mockMvc.perform(post(requestURL)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(mapper.writeValueAsString(fcmTokenForm)));
+                    .content(mapper.writeValueAsString(fcmTokenRequest)));
 
             //then
             resultActions.andExpect(status().isBadRequest());


### PR DESCRIPTION
### 변경사항

- Request와 Response는 값이 들어오고 나갈때만 사용되고 또한, 내부 값을 변경 없이 사용해야 하여 불변객체로 변경합니다.
- 상수 필드만 받을 수 있게 RequiredArgsConstructor로 변경
- 필드 1개 경우 Jackson 라이브러리 역직렬화 오류로 (Properties vs. Delegating) Delegating으로 지정 위해 JsonCreator 태그 사용.([링크](https://kong-dev.tistory.com/236))
- GC 기다리지 않고 사용 후 바로 제거 될수 있게 wrapper 클래스 대신 기본형 사용 가능시 기본형 사용.