### PR TITLE
[46-request-기본형-필드]

### DIFF
--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/AlarmController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/AlarmController.java
@@ -38,10 +38,10 @@ public class AlarmController {
         public static final String ALARM_MESSAGE_NOT_FOUND = "알람 내용이 없습니다.";
 
         @NotNull(message = ALARM_X_NOT_FOUND)
-        private final double x;
+        private final Double x;
 
         @NotNull(message = ALARM_Y_NOT_FOUND)
-        private final double y;
+        private final Double y;
 
         @NotBlank(message = ALARM_TITLE_NOT_FOUND)
         private final String title;

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/SignUpController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/SignUpController.java
@@ -72,9 +72,10 @@ public class SignUpController {
         private final String address;
 
         @NotNull(message = LOCATION_SERVICE_VALIDATION_MESSAGE)
-        private final boolean isLocationServiceEnabled;
+        private final Boolean isLocationServiceEnabled;
 
         private final long point;
+
     }
 
 
@@ -106,10 +107,10 @@ public class SignUpController {
         private final String location;
 
         @NotNull(message = LOCATION_SERVICE_VALIDATION_MESSAGE)
-        private final boolean isLocationServiceEnabled;
+        private final Boolean isLocationServiceEnabled;
 
         @NotNull(message = POINT_UPDATE_VALIDATION_MESSAGE)
-        private final long point;
+        private final Long point;
     }
 
     @Getter

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TrackController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TrackController.java
@@ -53,10 +53,10 @@ public class TrackController {
         public static final String TRACK_TIMESTAMP_NOT_FOUND = "시간이 없습니다.";
 
         @NotNull(message = TRACK_LATITUDE_NOT_FOUND)
-        private final double latitude;
+        private final Double latitude;
 
         @NotNull(message = TRACK_LONGITUDE_NOT_FOUND)
-        private final double longitude;
+        private final Double longitude;
 
         @NotNull(message = TRACK_TIMESTAMP_NOT_FOUND)
         private final LocalDateTime timestamp;

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/dto/request/signUp/UpdateRequestTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/dto/request/signUp/UpdateRequestTest.java
@@ -31,23 +31,23 @@ class UpdateRequestTest {
     private SignUpServiceImpl signUpService;
 
     private final String requestURL = "/sign-in";
-    private SignUpController.UpdateRequest form;
+    private SignUpController.UpdateRequest req;
 
     @BeforeEach
     void setUp() {
-        form = mock(SignUpController.UpdateRequest.class);
+        req = mock(SignUpController.UpdateRequest.class);
     }
 
     @Test
     @DisplayName("회원 아이디(PK) 미입력.")
     void update_URL() throws Exception {
         //given
-        when(form.getId()).thenReturn(null);
+        when(req.getId()).thenReturn(null);
 
         //when
         ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest());
@@ -57,12 +57,12 @@ class UpdateRequestTest {
     @DisplayName("이름 미입력.")
     void update_NoName() throws Exception {
         //given
-        when(form.getName()).thenReturn(null);
+        when(req.getName()).thenReturn(null);
 
         //when
         ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest());
@@ -72,12 +72,12 @@ class UpdateRequestTest {
     @DisplayName("이메일 미입력.")
     void update_NoEmail() throws Exception {
         //given
-        when(form.getEmail()).thenReturn(null);
+        when(req.getEmail()).thenReturn(null);
 
         //when
         ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest());
@@ -87,12 +87,12 @@ class UpdateRequestTest {
     @DisplayName("이메일 형식 오류.")
     void update_InvalidEmail() throws Exception {
         //given
-        when(form.getEmail()).thenReturn("invalidEmail");
+        when(req.getEmail()).thenReturn("invalidEmail");
 
         //when
         ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest());
@@ -102,12 +102,12 @@ class UpdateRequestTest {
     @DisplayName("비밀번호 미입력.")
     void update_NoPassword() throws Exception {
         //given
-        when(form.getPassword()).thenReturn(null);
+        when(req.getPassword()).thenReturn(null);
 
         //when
         ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest());
@@ -117,12 +117,12 @@ class UpdateRequestTest {
     @DisplayName("전화번호 미입력.")
     void update_NoPhone() throws Exception {
         //given
-        when(form.getPhone()).thenReturn(null);
+        when(req.getPhone()).thenReturn(null);
 
         //when
         ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest());
@@ -132,12 +132,12 @@ class UpdateRequestTest {
     @DisplayName("위치 미입력.")
     void update_NoLocation() throws Exception {
         //given
-        when(form.getLocation()).thenReturn(null);
+        when(req.getLocation()).thenReturn(null);
 
         //when
         ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest());
@@ -147,12 +147,12 @@ class UpdateRequestTest {
     @DisplayName("위치 서비스 사용 여부 없음.")
     public void signUp_NoIsLocationServiceEnabled() throws Exception {
         //given
-        when(form.getIsLocationServiceEnabled()).thenReturn(null);
+        when(req.getIsLocationServiceEnabled()).thenReturn(null);
 
         //when
         ResultActions resultActions = mockMvc.perform(post(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest());
@@ -163,16 +163,15 @@ class UpdateRequestTest {
     @DisplayName("포인트 미입력.")
     void update_NoPoint() throws Exception {
         //given
-        when(form.getPoint()).thenReturn(null);
+        when(req.getPoint()).thenReturn(null);
 
         //when
         ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest());
     }
-
 
 }


### PR DESCRIPTION
### 변경사항
- Request에서 기본형 사용시 테스트에서 null값으로 스터빙 불가로 다시 래퍼 클래스로 변경
- 또한, 기본형 사용시에도 메소드 지역변수가 기본형이 아닌 이상 GC의 영향을 받기에 기대했던 효과가 없을 것이라 테스트 편의를 위해 다시 되돌리기로 결정.