### PR TITLE
[047-member-location-기본값-불변객체]

### DIFF
--- a/member-context/src/main/java/com/membercontext/memberAPI/application/exception/member/MemberErrorCode.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/exception/member/MemberErrorCode.java
@@ -25,8 +25,8 @@ public enum MemberErrorCode {
     SIGNUP_FAILED(HttpStatus.BAD_REQUEST, "회원가입이 실패하였습니다."),
 
     //Location
-    LOCATION_SERVICE_NOT_PERMITTED(HttpStatus.BAD_REQUEST, "위치정보 서비스가 허용되지 않았습니다.");
-
+    LOCATION_SERVICE_NOT_PERMITTED(HttpStatus.BAD_REQUEST, "위치정보 서비스가 허용되지 않았습니다."),
+    NO_VALUE(HttpStatus.BAD_REQUEST, "값이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String deatil;

--- a/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/Member.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/Member.java
@@ -40,7 +40,7 @@ public class Member {
 
     @Embedded
     @Builder.Default
-    private MemberLocation memberLocation = new MemberLocation().UNKNOWN;
+    private MemberLocation memberLocation = MemberLocation.UNKNOWN;
 
     private Long point;
 

--- a/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/MemberLocation.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/MemberLocation.java
@@ -2,61 +2,81 @@ package com.membercontext.memberAPI.domain.entity.member;
 
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import jakarta.persistence.Embeddable;
-import lombok.Getter;
+import lombok.*;
 
+import javax.annotation.Nullable;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.LOCATION_SERVICE_NOT_PERMITTED;
+import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.NO_VALUE;
+
 
 @Embeddable
-@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 public final class MemberLocation {
 
-    public static MemberLocation UNKNOWN = new MemberLocation(0, 0, LocalDateTime.now(), "NOT_AVAILABLE");
+    public static MemberLocation UNKNOWN = new MemberLocation(null, null, null, "NOT_AVAILABLE");
 
-    private double latitude;
-    private double longitude;
-    private LocalDateTime timestamp;
-    private String fcmToken; //check: 엄밀히 말하면 여기는 다른 context
+    @Nullable
+    private final Double latitude;
 
+    @Nullable
+    private final Double longitude;
 
-    private MemberLocation(double i, double i1, LocalDateTime currentTime, String fcmToken) {
-        this.latitude = i;
-        this.longitude = i1;
-        this.timestamp = currentTime;
+    @Nullable
+    private final LocalDateTime timestamp;
+
+    @Getter
+    private final String fcmToken; //check: 엄밀히 말하면 여기는 다른 context
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private MemberLocation(@Nullable Double latitude, @Nullable Double longitude, @Nullable LocalDateTime timestamp, @Nullable String fcmToken) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.timestamp = timestamp;
         this.fcmToken = fcmToken;
     }
 
-    protected MemberLocation() {
-    }
-
-    public MemberLocation addLocation(double latitude, double longitude, LocalDateTime timestamp) {
+    public MemberLocation addLocation(Double latitude, Double longitude, LocalDateTime timestamp) {
+        if (latitude == null || longitude == null || timestamp == null) {
+            throw new MemberException(NO_VALUE);
+        }
         return new MemberLocation(latitude, longitude, timestamp, this.fcmToken);
     }
 
     public MemberLocation addFCMToken(String token) {
+        if (token == null) {
+            throw new MemberException(NO_VALUE);
+        }
         return new MemberLocation(this.latitude, this.longitude, this.timestamp, token);
     }
 
-    public LocalDateTime getTimeStamp(Member member) {
+    public Optional<LocalDateTime> getTimestamp(Member member) {
         if (!member.isLocationServiceEnabled()) {
             throw new MemberException(LOCATION_SERVICE_NOT_PERMITTED);
         }
-        return this.timestamp;
+        return Optional.ofNullable(this.timestamp);
     }
 
-    public double getLongitude(Member member) {
+    public Optional<Double> getLongitude(Member member) {
         if (!member.isLocationServiceEnabled()) {
             throw new MemberException(LOCATION_SERVICE_NOT_PERMITTED);
         }
-        return longitude;
+        return Optional.ofNullable(this.longitude);
     }
 
-    public double getLatitude(Member member) {
+    public Optional<Double> getLatitude(Member member) {
         if (!member.isLocationServiceEnabled()) {
             throw new MemberException(LOCATION_SERVICE_NOT_PERMITTED);
         }
-        return latitude;
+        return Optional.ofNullable(this.latitude);
     }
+    //todo: FCM token도 nullable 하도록 변경
+//
+//    public Optional<String> getFcmToken(Member member) {
+//        return Optional.ofNullable(this.fcmToken);
+//    }
+
 
 }

--- a/member-context/src/test/java/com/membercontext/common/stub/MemberJPARepositoryStub.java
+++ b/member-context/src/test/java/com/membercontext/common/stub/MemberJPARepositoryStub.java
@@ -63,8 +63,15 @@ public class MemberJPARepositoryStub implements MemberRepository {
     @Override
     public List<Member> findNearByMember(double x, double y, int radius) {
         return members.stream().filter(member ->
-                (Math.pow(member.getMemberLocation().getLongitude(), 2)
-                        + Math.pow(member.getMemberLocation().getLatitude(), 2))
-                        <= Math.pow((radius / Math.pow(10, 5)), 2)).toList();
+        {
+            Optional<Double> longitude = member.getMemberLocation().getLongitude(member);
+            Optional<Double> latitude = member.getMemberLocation().getLatitude(member);
+            if (longitude.isPresent()) {
+                return (Math.pow(longitude.get(), 2) + Math.pow(latitude.get(), 2))
+                        <= Math.pow((radius / Math.pow(10, 5)), 2);
+            } else {
+                return false;
+            }
+        }).toList();
     }
 }

--- a/member-context/src/test/java/com/membercontext/common/stub/MemberSpringJPARepositoryStub.java
+++ b/member-context/src/test/java/com/membercontext/common/stub/MemberSpringJPARepositoryStub.java
@@ -46,9 +46,16 @@ public class MemberSpringJPARepositoryStub implements MemberSpringJPARepository 
     @Override
     public List<Member> findNearByMember(double x, double y, int radius) {
         return members.stream().filter(member ->
-                (Math.pow(member.getMemberLocation().getLongitude(), 2)
-                        + Math.pow(member.getMemberLocation().getLatitude(), 2))
-                        <= Math.pow((radius / Math.pow(10, 5)), 2)).toList();
+        {
+            Optional<Double> longitude = member.getMemberLocation().getLongitude(member);
+            Optional<Double> latitude = member.getMemberLocation().getLatitude(member);
+            if (longitude.isPresent()) {
+                return (Math.pow(longitude.get(), 2) + Math.pow(latitude.get(), 2))
+                        <= Math.pow((radius / Math.pow(10, 5)), 2);
+            } else {
+                return false;
+            }
+        }).toList();
     }
 
     @Override

--- a/member-context/src/test/java/com/membercontext/common/stub/test/MemberJPARepositoryStubIntegratedTest.java
+++ b/member-context/src/test/java/com/membercontext/common/stub/test/MemberJPARepositoryStubIntegratedTest.java
@@ -231,6 +231,8 @@ class MemberJPARepositoryStubIntegratedTest {
         void findNearByMember() {
             //given
             Member member = MemberFixture.create();
+            TrackController.TrackRequest targetLocation = TrackRequestFixture.createRequestWithDifferentLocation(0, 0);
+            member.updateLocation(targetLocation);
             db.save(member);
             stub.save(member);
 
@@ -247,7 +249,22 @@ class MemberJPARepositoryStubIntegratedTest {
 
             assertEquals(2, stubResult.size());
             assertEquals(2, dbResult.size());
+        }
 
+        @Test
+        @DisplayName("findNearByMember - 위치 값 없는 맴버")
+        void findNearByMember_NoLocation() {
+            Member member = MemberFixture.create();
+            db.save(member);
+            stub.save(member);
+
+            //when
+            List<Member> stubResult = stub.findNearByMember(0, 0, 10);
+            List<Member> dbResult = db.findNearByMember(0, 0, 10);
+
+            assertEquals(dbResult.size(), stubResult.size());
+            assertEquals(0, stubResult.size());
+            assertEquals(0, dbResult.size());
         }
 
         @Test
@@ -255,6 +272,8 @@ class MemberJPARepositoryStubIntegratedTest {
         void findNearByMember_OtherFar() {
             //given
             Member member = MemberFixture.create();
+            TrackController.TrackRequest targetLocation = TrackRequestFixture.createRequestWithDifferentLocation(0, 0);
+            member.updateLocation(targetLocation);
             db.save(member);
             stub.save(member);
 

--- a/member-context/src/test/java/com/membercontext/common/stub/test/MemberSpringJPARespotiroyStubIntegratedTest.java
+++ b/member-context/src/test/java/com/membercontext/common/stub/test/MemberSpringJPARespotiroyStubIntegratedTest.java
@@ -166,6 +166,10 @@ public class MemberSpringJPARespotiroyStubIntegratedTest {
         @DisplayName("findNearByMember - 가까이 있는 맴버.")
         void findNearByMember() {
             //given
+            TrackController.TrackRequest targetLocation = TrackRequestFixture.createRequestWithDifferentLocation(0, 0);
+            dbMember.updateLocation(targetLocation);
+            stubMember.updateLocation(targetLocation);
+
             Member memberNearBy = MemberFixture.createMemberWithDifferentEmail("memberNearBy@test.com");
             TrackController.TrackRequest request = TrackRequestFixture.createRequestWithDifferentLocation(0, 0.002);
             memberNearBy.updateLocation(request);
@@ -177,14 +181,31 @@ public class MemberSpringJPARespotiroyStubIntegratedTest {
             List<Member> stubResult = stub.findNearByMember(0, 0, 500);
             List<Member> dbResult = memberSpringJPARepository.findNearByMember(0, 0, 500);
 
+            assertEquals(dbResult.size(), stubResult.size());
             assertEquals(2, stubResult.size());
             assertEquals(2, dbResult.size());
-
         }
+
+        @Test
+        @DisplayName("findNearByMember - 위치 값 없는 맴버")
+        void findNearByMember_NoLocation() {
+            //when
+            List<Member> stubResult = stub.findNearByMember(0, 0, 10);
+            List<Member> dbResult = memberSpringJPARepository.findNearByMember(0, 0, 10);
+
+            assertEquals(dbResult.size(), stubResult.size());
+            assertEquals(0, stubResult.size());
+            assertEquals(0, dbResult.size());
+        }
+
 
         @Test
         @DisplayName("findNearByMember - 떨어져 있는 맴버.")
         void findNearByMember_OtherFar() {
+            TrackController.TrackRequest targetLocation = TrackRequestFixture.createRequestWithDifferentLocation(0, 0);
+            dbMember.updateLocation(targetLocation);
+            stubMember.updateLocation(targetLocation);
+
             //given
             Member memberFar = MemberFixture.createMemberWithDifferentEmail("MemberFar@test.com");
             TrackController.TrackRequest request = TrackRequestFixture.createRequestWithDifferentLocation(400, 400);
@@ -193,11 +214,11 @@ public class MemberSpringJPARespotiroyStubIntegratedTest {
             stub.save(memberFar);
             memberSpringJPARepository.save(memberFar);
 
-
             //when
             List<Member> stubResult = stub.findNearByMember(0, 0, 10);
             List<Member> dbResult = memberSpringJPARepository.findNearByMember(0, 0, 10);
 
+            assertEquals(dbResult.size(), stubResult.size());
             assertEquals(1, stubResult.size());
             assertEquals(1, dbResult.size());
         }

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/service/AlarmServiceTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/service/AlarmServiceTest.java
@@ -1,11 +1,13 @@
 package com.membercontext.memberAPI.application.service;
 
 import com.membercontext.common.fixture.web.AlarmRequestFixture;
+import com.membercontext.common.fixture.web.TrackRequestFixture;
 import com.membercontext.common.stub.MemberJPARepositoryStub;
 import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.common.fixture.domain.MemberFixture;
 import com.membercontext.memberAPI.web.controller.AlarmController;
+import com.membercontext.memberAPI.web.controller.TrackController;
 import com.membercontext.memberAPI.web.pushMessage.FireBaseCloudMessageClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -44,10 +46,14 @@ class AlarmServiceTest {
         void sendPushMessage() {
             // given
             AlarmController.AlarmRequest alarmForm = AlarmRequestFixture.create();
+            TrackController.TrackRequest req = TrackRequestFixture.createRequestWithDifferentLocation(0, 0);
 
             Member member1 = MemberFixture.createMemberWithId("UUID");
-            Member member2 = MemberFixture.createMemberWithId("UUID2");
+            member1.updateLocation(req);
             memberRepository.save(member1);
+
+            Member member2 = MemberFixture.createMemberWithId("UUID2");
+            member2.updateLocation(req);
             memberRepository.save(member2);
 
             //when
@@ -75,7 +81,6 @@ class AlarmServiceTest {
             //then
             verify(fireBaseCloudMessageClient, never()).sendMultipleMessages(anyList(), anyString(), anyString());
         }
-
-
     }
+
 }

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/service/TrackServiceTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/service/TrackServiceTest.java
@@ -7,6 +7,7 @@ import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 
 import com.membercontext.memberAPI.web.controller.TrackController;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,6 +29,7 @@ class TrackServiceTest {
     private MemberRepository memberRepository = new MemberJPARepositoryStub();
 
     @Test
+    @DisplayName("현재 위치 저장")
     void saveCurrentLocation() {
         // given
         Member member = MemberFixture.create();
@@ -39,12 +41,13 @@ class TrackServiceTest {
 
         // then
         Member updatedMember = memberRepository.findById(id);
-        assertEquals(updatedMember.getMemberLocation().getLongitude(), form.getLongitude());
-        assertEquals(updatedMember.getMemberLocation().getLatitude(), form.getLatitude());
-        assertEquals(updatedMember.getMemberLocation().getTimestamp(), form.getTimestamp());
+        assertEquals(updatedMember.getMemberLocation().getLongitude(updatedMember).get(), form.getLongitude());
+        assertEquals(updatedMember.getMemberLocation().getLatitude(updatedMember).get(), form.getLatitude());
+        assertEquals(updatedMember.getMemberLocation().getTimestamp(updatedMember).get(), form.getTimestamp());
     }
 
     @Test
+    @DisplayName("FCM 토큰 저장")
     void saveToken() {
         // given
         String token = "token";

--- a/member-context/src/test/java/com/membercontext/memberAPI/domain/entity/member/MemberLocationTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/domain/entity/member/MemberLocationTest.java
@@ -3,11 +3,18 @@ package com.membercontext.memberAPI.domain.entity.member;
 import com.membercontext.common.fixture.domain.MemberFixture;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.LOCATION_SERVICE_NOT_PERMITTED;
+import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.NO_VALUE;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MemberLocationTest {
@@ -23,88 +30,136 @@ class MemberLocationTest {
 
         //then
         assertEquals(memberLocation.getFcmToken(), MemberLocation.UNKNOWN.getFcmToken());
-        assertEquals(memberLocation.getLatitude(), MemberLocation.UNKNOWN.getLatitude());
-        assertEquals(memberLocation.getLongitude(), MemberLocation.UNKNOWN.getLongitude());
-        assertEquals(memberLocation.getTimestamp(), MemberLocation.UNKNOWN.getTimestamp());
+        assertThrows(NoSuchElementException.class, () -> memberLocation.getLatitude(member).get());
+        assertThrows(NoSuchElementException.class, () -> memberLocation.getLongitude(member).get());
+        assertThrows(NoSuchElementException.class, () -> memberLocation.getTimestamp(member).get());
     }
 
-    @Test
+    @Nested
     @DisplayName("위치 추가")
-    void addLocation() {
-        //given
-        Member member = MemberFixture.create();
-        MemberLocation memberLocation = member.getMemberLocation();
+    class addLocation {
+        @Test
+        @DisplayName("위치 추가 - 성공")
+        void addLocation() {
+            //given
+            Member member = MemberFixture.create();
+            MemberLocation memberLocation = member.getMemberLocation();
 
-        //when
-        MemberLocation changedMemberLocation = memberLocation.addLocation(1.0, 2.0, LocalDateTime.of(2021, 1, 1, 0, 0, 0));
+            //when
+            MemberLocation changedMemberLocation = memberLocation.addLocation(1.0, 2.0, LocalDateTime.of(2021, 1, 1, 0, 0, 0));
 
-        //then
-        assertEquals(1.0, changedMemberLocation.getLatitude());
-        assertEquals(2.0, changedMemberLocation.getLongitude());
-        assertEquals(LocalDateTime.of(2021, 1, 1, 0, 0, 0), changedMemberLocation.getTimestamp());
-        assertEquals(MemberLocation.UNKNOWN.getFcmToken(), changedMemberLocation.getFcmToken());
+            //then
+            assertEquals(1.0, changedMemberLocation.getLatitude(member).get());
+            assertEquals(2.0, changedMemberLocation.getLongitude(member).get());
+            assertEquals(LocalDateTime.of(2021, 1, 1, 0, 0, 0), changedMemberLocation.getTimestamp(member).get());
+            assertEquals(MemberLocation.UNKNOWN.getFcmToken(), changedMemberLocation.getFcmToken());
+        }
+
+        static Stream<Arguments> nullCases() {
+            return Stream.of(
+                    Arguments.of(null, 2.0, LocalDateTime.of(2021, 1, 1, 0, 0, 0), "위도 없음"),
+                    Arguments.of(1.0, null, LocalDateTime.of(2021, 1, 1, 0, 0, 0), "경도 없음"),
+                    Arguments.of(1.0, 2.0, null, "시간 없음")
+            );
+        }
+
+        @ParameterizedTest(name = "{index} - {3}")
+        @MethodSource("nullCases")
+        @DisplayName("위치 추가 - 예외 경우")
+        void addLocation_WHEN_NO_VALUE(Double latitude, Double longitude, LocalDateTime timestamp, String testName) {
+            //given
+            Member member = MemberFixture.create();
+            MemberLocation memberLocation = member.getMemberLocation();
+
+            //when
+            Exception exception = assertThrows(MemberException.class, () -> memberLocation.addLocation(latitude, longitude, timestamp));
+
+            //then
+            assertEquals(exception.getClass(), MemberException.class);
+            assertEquals(exception.getMessage(), NO_VALUE.getDeatil());
+        }
+
     }
 
-    @Test
+    @Nested
     @DisplayName("FCM 토큰 추가")
-    void addFcmToken() {
-        //given
-        Member member = MemberFixture.create();
-        MemberLocation memberLocation = member.getMemberLocation();
+    class addFcmToken {
+        @Test
+        @DisplayName("FCM 토큰 추가 - 성공")
+        void addFcmToken() {
+            //given
+            Member member = MemberFixture.create();
+            MemberLocation memberLocation = member.getMemberLocation();
 
+            //when
+            MemberLocation changedMemberLocation = memberLocation.addFCMToken("token");
 
-        //when
-        MemberLocation changedMemberLocation = memberLocation.addFCMToken("token");
+            //then
+            assertEquals("token", changedMemberLocation.getFcmToken());
+        }
 
-        //then
-        assertEquals("token", changedMemberLocation.getFcmToken());
-        assertEquals(MemberLocation.UNKNOWN.getLatitude(), changedMemberLocation.getLatitude());
-        assertEquals(MemberLocation.UNKNOWN.getLongitude(), changedMemberLocation.getLongitude());
-        assertEquals(MemberLocation.UNKNOWN.getTimestamp(), changedMemberLocation.getTimestamp());
+        @Test
+        @DisplayName("FCM 토큰 추가 - 예외 경우")
+        void addFcmToken_WHEN_NO_VALUE() {
+            //given
+            Member member = MemberFixture.create();
+            MemberLocation memberLocation = member.getMemberLocation();
+
+            //when
+            Exception exception = assertThrows(MemberException.class, () -> memberLocation.addFCMToken(null));
+
+            //then
+            assertEquals(exception.getClass(), MemberException.class);
+            assertEquals(exception.getMessage(), NO_VALUE.getDeatil());
+        }
     }
 
-    @Test
-    @DisplayName("시간 확인 - 예외 경우")
-    void getTimeStamp_WHEN_NOT_PERMITTED() {
-        //given
-        Member member = MemberFixture.createMemberWithIdANDLocationNotAgreed("UUID");
+    @Nested
+    @DisplayName("커스텀 게터들")
+    class getters {
+        @Test
+        @DisplayName("시간 확인 - 예외 경우")
+        void getTimeStamp_WHEN_NOT_PERMITTED() {
+            //given
+            Member member = MemberFixture.createMemberWithIdANDLocationNotAgreed("UUID");
 
-        //when
-        MemberLocation memberLocation = member.getMemberLocation();
-        Exception exception = assertThrows(MemberException.class, () -> memberLocation.getTimeStamp(member));
+            //when
+            MemberLocation memberLocation = member.getMemberLocation();
+            Exception exception = assertThrows(MemberException.class, () -> memberLocation.getTimestamp(member));
 
-        //then
-        assertEquals(exception.getClass(), MemberException.class);
-        assertEquals(exception.getMessage(), LOCATION_SERVICE_NOT_PERMITTED.getDeatil());
-    }
+            //then
+            assertEquals(exception.getClass(), MemberException.class);
+            assertEquals(exception.getMessage(), LOCATION_SERVICE_NOT_PERMITTED.getDeatil());
+        }
 
-    @Test
-    @DisplayName("경도 확인 - 예외 경우")
-    void getLongitude_WHEN_NOT_PERMITTED() {
-        //given
-        Member member = MemberFixture.createMemberWithIdANDLocationNotAgreed("UUID");
+        @Test
+        @DisplayName("경도 확인 - 예외 경우")
+        void getLongitude_WHEN_NOT_PERMITTED() {
+            //given
+            Member member = MemberFixture.createMemberWithIdANDLocationNotAgreed("UUID");
 
-        //when
-        MemberLocation memberLocation = member.getMemberLocation();
-        Exception exception = assertThrows(MemberException.class, () -> memberLocation.getLongitude(member));
+            //when
+            MemberLocation memberLocation = member.getMemberLocation();
+            Exception exception = assertThrows(MemberException.class, () -> memberLocation.getLongitude(member));
 
-        //then
-        assertEquals(exception.getClass(), MemberException.class);
-        assertEquals(exception.getMessage(), LOCATION_SERVICE_NOT_PERMITTED.getDeatil());
-    }
+            //then
+            assertEquals(exception.getClass(), MemberException.class);
+            assertEquals(exception.getMessage(), LOCATION_SERVICE_NOT_PERMITTED.getDeatil());
+        }
 
-    @Test
-    @DisplayName("위도 확인 - 예외 경우")
-    void getLatitude_WHEN_NOT_PERMITTED() {
-        //given
-        Member member = MemberFixture.createMemberWithIdANDLocationNotAgreed("UUID");
+        @Test
+        @DisplayName("위도 확인 - 예외 경우")
+        void getLatitude_WHEN_NOT_PERMITTED() {
+            //given
+            Member member = MemberFixture.createMemberWithIdANDLocationNotAgreed("UUID");
 
-        //when
-        MemberLocation memberLocation = member.getMemberLocation();
-        Exception exception = assertThrows(MemberException.class, () -> memberLocation.getLatitude(member));
+            //when
+            MemberLocation memberLocation = member.getMemberLocation();
+            Exception exception = assertThrows(MemberException.class, () -> memberLocation.getLatitude(member));
 
-        //then
-        assertEquals(exception.getClass(), MemberException.class);
-        assertEquals(exception.getMessage(), LOCATION_SERVICE_NOT_PERMITTED.getDeatil());
+            //then
+            assertEquals(exception.getClass(), MemberException.class);
+            assertEquals(exception.getMessage(), LOCATION_SERVICE_NOT_PERMITTED.getDeatil());
+        }
     }
 }

--- a/member-context/src/test/java/com/membercontext/memberAPI/domain/entity/member/MemberTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/domain/entity/member/MemberTest.java
@@ -68,9 +68,9 @@ class MemberTest {
         member.updateLocation(req);
 
         //then
-        assertEquals(req.getLatitude(), member.getMemberLocation().getLatitude());
-        assertEquals(req.getLongitude(), member.getMemberLocation().getLongitude());
-        assertEquals(req.getTimestamp(), member.getMemberLocation().getTimestamp());
+        assertEquals(req.getLatitude(), member.getMemberLocation().getLatitude(member).get());
+        assertEquals(req.getLongitude(), member.getMemberLocation().getLongitude(member).get());
+        assertEquals(req.getTimestamp(), member.getMemberLocation().getTimestamp(member).get());
     }
 
     @Test

--- a/member-context/src/test/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepositoryTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepositoryTest.java
@@ -205,9 +205,10 @@ class MemberJPARepositoryTest {
             int radius = 500; // 500km
 
             Member memberAt0 = MemberFixture.create();
+            memberAt0.updateLocation(TrackRequestFixture.createRequestWithDifferentLocation(x, y));
+
             Member memberNear = MemberFixture.createMemberWithDifferentEmail("nearMember@test.com");
-            TrackController.TrackRequest request = TrackRequestFixture.createRequestWithDifferentLocation(0, 0.002);
-            memberNear.updateLocation(request);
+            memberNear.updateLocation(TrackRequestFixture.createRequestWithDifferentLocation(0, 0.002));
 
             memberSpringJPARepository.save(memberAt0);
             memberNear = memberSpringJPARepository.save(memberNear);
@@ -222,6 +223,22 @@ class MemberJPARepositoryTest {
         }
 
         @Test
+        @DisplayName("주변 회원 조회 - 위치값 없는 회원.")
+        void findNearByMember_farAway() { //없는 경우
+            //given
+            double x = 0;
+            double y = 0;
+            int radius = 1;
+            Member memberAt0 = MemberFixture.create();
+            memberSpringJPARepository.save(memberAt0);
+
+            List<Member> list = sut.findNearByMember(x, y, radius);
+
+            System.out.println(list.size());
+        }
+
+
+        @Test
         @DisplayName("주변 회원 조회 - 실패.")
         void findNearByMember_nearBy() {
             //given
@@ -230,9 +247,10 @@ class MemberJPARepositoryTest {
             int radius = 1;
 
             Member memberAt0 = MemberFixture.create();
+            memberAt0.updateLocation(TrackRequestFixture.createRequestWithDifferentLocation(x, y));
+
             Member memberFar = MemberFixture.createMemberWithDifferentEmail("farMember@test.com");
-            TrackController.TrackRequest request = TrackRequestFixture.createRequestWithDifferentLocation(300, 300);
-            memberFar.updateLocation(request);
+            memberFar.updateLocation(TrackRequestFixture.createRequestWithDifferentLocation(300, 300));
 
             memberSpringJPARepository.save(memberAt0);
             memberFar = memberSpringJPARepository.save(memberFar);


### PR DESCRIPTION
### 변경사항

- MemberLocation을 불변객체로 만들고 기본값을 null로 사용하도록 바꾸었습니다.
  - 불변객체라 변경사항을 잘 다루면 null을 관리할 수 있을것이라고 생각했습니다.
    - 변경시에는 null 체크를 해서 최초 생성시에만 null이도록 하였습니다. (addLocation / addFCMToken 메서드들)
    - null일 수 있는 필드들의 경우 Nullable 어노테이션을 붙이고 Optional을 리턴하는 게터를 만들어 값을 사용할때 널체크를 하고 사용하도록 하였습니다. 

- Stub 클래스가 예상대로 작동하지 않아서 이슈가 있었지만 수정하였습니다. 
  - 널값을 어떻게 처리하는 가였는데, db와 다르게 동작하였습니다.
  - Stub 클래스의 경우 repository 관련 테스트에 종류가 추가되면 다시 db와 통합테스트를 돌려야 된다는 것을 알았습니다.   