### PR TITLE
[Hotfix-05-인증-aop-정상화]

### DIFF
--- a/member-context/src/main/java/com/membercontext/memberAPI/application/aop/authentication/AuthenticationAspect.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/aop/authentication/AuthenticationAspect.java
@@ -1,17 +1,14 @@
 package com.membercontext.memberAPI.application.aop.authentication;
 
-import com.membercontext.memberAPI.application.exception.member.MemberErrorCode;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
+import com.membercontext.memberAPI.web.controller.LogInController;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
-import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.lang.reflect.Member;
 
 import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.*;
 
@@ -30,7 +27,7 @@ public class AuthenticationAspect {
     }
 
     private String checkCookie() {
-        final String cookieName = "CKIB4LV";
+        final String cookieName = LogInController.COOKIE_NAME;
         Cookie[] cookies = request.getCookies();
 
         if (cookies == null) {

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/LogInController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/LogInController.java
@@ -19,10 +19,11 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
-@Controller
+@RestController
 @RequestMapping("/log-in")
 @RequiredArgsConstructor
 public class LogInController {

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/MemberInfoController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/MemberInfoController.java
@@ -8,8 +8,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequestMapping("/info/member")
 @RequiredArgsConstructor
 public class MemberInfoController {

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/SignUpController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/SignUpController.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/sign-in")
 public class SignUpController {

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TestController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TestController.java
@@ -1,20 +1,25 @@
 package com.membercontext.memberAPI.web.controller;
 
+import com.membercontext.memberAPI.application.aop.authentication.NoAuthentication;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequestMapping("/test")
 public class TestController {
 
     @PostMapping
+    @NoAuthentication
     public void test() {
         System.out.println("test Post on going");
     }
+
     @GetMapping
+    @NoAuthentication
     public void test2() {
         System.out.println("test Get on going");
     }

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TrackController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TrackController.java
@@ -36,9 +36,8 @@ public class TrackController {
 
     @PostMapping(value = "/token", consumes = "application/json")
     public ResponseEntity<DefaultHTTPResponse<Void>> token(@CookieValue(value = COOKIE_NAME) String cookieValue, HttpServletRequest request, @Validated @RequestBody FCMTokenRequest fcmTokenRequest) {
-        String email = (String) request.getSession().getAttribute(cookieValue);
-        System.out.println(fcmTokenRequest.getToken());
-        trackService.saveToken(fcmTokenRequest.getToken(), email);
+        String id = (String) request.getSession().getAttribute(cookieValue);
+        trackService.saveToken(fcmTokenRequest.getToken(), id);
 
         return ResponseEntity.ok().body(new DefaultHTTPResponse<>(FCM_TOKEN_REGISTERED));
     }

--- a/member-context/src/test/java/com/membercontext/common/LogInTestHelper.java
+++ b/member-context/src/test/java/com/membercontext/common/LogInTestHelper.java
@@ -6,7 +6,9 @@ import com.membercontext.memberAPI.application.service.LogInService;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.memberAPI.web.controller.LogInController;
 
+import jakarta.servlet.http.Cookie;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -14,11 +16,16 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.UUID;
 
+import static com.membercontext.memberAPI.web.controller.LogInController.COOKIE_NAME;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 public class LogInTestHelper {
+
+    public static Cookie TEST_COOKIE;
+    public static MockHttpSession TEST_SESSION;
+
 
     public static MvcResult Login() throws Exception {
 
@@ -37,6 +44,11 @@ public class LogInTestHelper {
         ResultActions resultActions = mockMvc.perform(post(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(form)));
+
+        MvcResult result = resultActions.andReturn();
+        TEST_COOKIE = result.getResponse().getCookie(COOKIE_NAME);
+        TEST_SESSION = (MockHttpSession) result.getRequest().getSession();
+
 
         return resultActions.andReturn();
     }

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/aop/authentication/AuthenticationAspectTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/aop/authentication/AuthenticationAspectTest.java
@@ -1,39 +1,38 @@
 package com.membercontext.memberAPI.application.aop.authentication;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.membercontext.common.LogInTestHelper;
+import com.membercontext.common.fixture.domain.MemberFixture;
+import com.membercontext.common.fixture.web.crud.UpdateRequestFixture;
+import com.membercontext.memberAPI.application.exception.member.MemberErrorCode;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import com.membercontext.memberAPI.application.service.SignUpSerivces.SignUpService;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
-import com.membercontext.memberAPI.infrastructure.encryption.db.JavaCryptoIVRepository;
 import com.membercontext.memberAPI.web.controller.SignUpController;
-import com.membercontext.memberAPI.web.controller.fixture.SignUpFormTestFixture;
-import com.membercontext.memberAPI.web.controller.fixture.UpdateFormTestFixture;
-import com.membercontext.memberAPI.web.controller.form.SignUpForm;
-import com.membercontext.memberAPI.web.dto.MemberDto;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.*;
-import org.mockito.MockedStatic;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.util.UUID;
+import java.util.Collections;
 
+import static com.membercontext.memberAPI.web.controller.LogInController.COOKIE_NAME;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(SignUpController.class)
-@Import(JavaCryptoUtil.class)
-@Disabled
+@WebMvcTest({SignUpController.class})
 class AuthenticationAspectTest {
     @Autowired
     private MockMvc mockMvc;
@@ -41,100 +40,88 @@ class AuthenticationAspectTest {
     @Autowired
     private ObjectMapper mapper;
 
-    @Autowired
+    @MockBean
     JavaCryptoUtil encryption;
 
-    @MockBean
-    JavaCryptoIVRepository javaCryptoIVRepository;
-
     @SpyBean
-    private AuthenticationAspect authenticationAspect;
+    private AuthenticationAspect authenticationAspect; //이게 빈으로 있어야 AOP 작동.
 
     @MockBean
     private SignUpService signUpService;
 
-    private final String requestURL = "/log-in";
-    @Autowired
-    private JavaCryptoUtil javaCryptoUtil;
-
+    private final String requestURL = "/sign-in";
 
     @Test
     @DisplayName("인증 AOP 작동 중")
     void authenticateAOP() throws Exception {
         //given
-        SignUpForm form = new SignUpFormTestFixture().createAllFilledSignUpForm_Mock();
-        when(signUpService.signUp(any(Member.class))).thenReturn("회원가입 성공");
+        SignUpController.UpdateRequest req = UpdateRequestFixture.create();
+        when(signUpService.update(any(Member.class))).thenReturn(MemberFixture.createMemberWithId("UUID"));
 
-        final String cookieName = "CKIB4LV";
-        String encryptedEmail = encryption.encrypt(form.getEmail());
-        String sessionId = UUID.randomUUID().toString();
+        MvcResult result = LogInTestHelper.Login();
+        Cookie cookie = result.getResponse().getCookie(COOKIE_NAME);
+        MockHttpSession session = (MockHttpSession) result.getRequest().getSession();
 
         //when
-        ResultActions resultActions = mockMvc.perform(post(requestURL)
+        ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .cookie(new Cookie(cookieName, encryptedEmail))
-                .sessionAttr(encryptedEmail, sessionId)
-                .content(mapper.writeValueAsString(form)));
+                .cookie(cookie)
+                .session(session)
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$").value("회원가입 성공"))
-                .andExpect(result -> {
-                    //Cookie
-                    assertEquals("CKIB4LV", result.getRequest().getCookies()[0].getName());
-                    assertEquals(encryptedEmail, result.getRequest().getCookies()[0].getValue());
-                    assertEquals(javaCryptoUtil.encrypt("test@test.com"), result.getRequest().getCookies()[0].getValue());
-
-                    //Session
-                    assertEquals(sessionId, result.getRequest().getSession().getAttribute(encryptedEmail));
-                    assertEquals(sessionId, result.getRequest().getSession().getAttribute(javaCryptoUtil.encrypt("test@test.com")));
-                })
-                .andExpect(request().sessionAttribute(encryptedEmail, sessionId));
+                .andExpect(jsonPath("$.message").value(SignUpController.MEMBER_UPDATE_SUCCESS_MESSAGE))
+                .andExpect(resultReturned -> {
+                    assertEquals(COOKIE_NAME, resultReturned.getRequest().getCookies()[0].getName());
+                    assertTrue(Collections.list(session.getAttributeNames()).contains(cookie.getValue()));
+                });
         verify(authenticationAspect, times(1)).authenticate();
     }
+
     @Test
     @DisplayName("도메인의 로그인 쿠키 없음.")
     void authenticateAOP_Wrong_Cookie() throws Exception {
         //given
-        SignUpForm form = new SignUpFormTestFixture().createAllFilledSignUpForm_Mock();
-        when(signUpService.signUp(any(Member.class))).thenReturn("회원가입 성공");
-        final String cookieName = "CKIB4LV";
+        SignUpController.UpdateRequest req = UpdateRequestFixture.create();
+        when(signUpService.update(any(Member.class))).thenReturn(MemberFixture.createMemberWithId("UUID"));
 
         //when
-        ResultActions resultActions = mockMvc.perform(post(requestURL)
+        ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .cookie(new Cookie("otherDomain", "otherDomainValue"))
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest())
                 .andExpect(result -> {
-                    assertNotEquals("CKIB4LV", result.getRequest().getCookies()[0].getName());
-                    assertTrue(result.getResolvedException() instanceof MemberException);
-                    assertEquals("로그인 정보가 없습니다. 로그인이 필요합니다.", result.getResolvedException().getMessage());
+                    assertNotEquals(COOKIE_NAME, result.getRequest().getCookies()[0].getName());
+                    assertInstanceOf(MemberException.class, result.getResolvedException());
+                    assertEquals(MemberErrorCode.NOT_LOGGED_IN.getDeatil(), result.getResolvedException().getMessage());
                 });
 
         verify(authenticationAspect, times(1)).authenticate();
     }
+
     @Test
     @DisplayName("쿠키 없음")
     void authenticateAOP_No_Cookie() throws Exception {
         //given
-        SignUpForm form = new SignUpFormTestFixture().createAllFilledSignUpForm_Mock();
-        when(signUpService.signUp(any(Member.class))).thenReturn("회원가입 성공");
+        SignUpController.UpdateRequest req = UpdateRequestFixture.create();
+        when(signUpService.update(any(Member.class))).thenReturn(MemberFixture.createMemberWithId("UUID"));
 
         //when
-        ResultActions resultActions = mockMvc.perform(post(requestURL)
+        ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
-        resultActions.andExpect(status().isBadRequest())
-                .andExpect(result -> {
-                    assertThrows(NullPointerException.class, () -> result.getRequest().getCookies()[0].getValue());
-                    assertTrue(result.getResolvedException() instanceof MemberException);
-                    assertEquals("이력을 찾을 수 없습니다. 로그인이 필요합니다.", result.getResolvedException().getMessage());
-                });
+        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(result -> {
+            assertThrows(NullPointerException.class, () -> result.getRequest().getCookies()[0].getValue());
+            assertInstanceOf(MemberException.class, result.getResolvedException());
+            assertEquals(MemberErrorCode.NO_COOKIE.getDeatil(), result.getResolvedException().getMessage());
+        });
         verify(authenticationAspect, times(1)).authenticate();
 
     }
@@ -143,49 +130,49 @@ class AuthenticationAspectTest {
     @DisplayName("세션 없음")
     void authenticateAOP_No_Session() throws Exception {
         //given
-        SignUpForm form = new SignUpFormTestFixture().createAllFilledSignUpForm_Mock();
-        when(signUpService.signUp(any(Member.class))).thenReturn("회원가입 성공");
+        SignUpController.UpdateRequest req = UpdateRequestFixture.create();
+        when(signUpService.update(any(Member.class))).thenReturn(MemberFixture.createMemberWithId("UUID"));
 
-        final String cookieName = "CKIB4LV";
-        String encryptedEmail = encryption.encrypt(form.getEmail());
+        MvcResult result = LogInTestHelper.Login();
+        Cookie cookie = result.getResponse().getCookie(COOKIE_NAME);
 
         //when
-        ResultActions resultActions = mockMvc.perform(post(requestURL)
+        ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .cookie(new Cookie(cookieName, encryptedEmail))
-                .content(mapper.writeValueAsString(form)));
+                .cookie(cookie)
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest())
-                .andExpect(result -> {
-                    assertTrue(result.getResolvedException() instanceof MemberException);
-                    assertEquals("서버에 세션이 존재하지 않습니다.", result.getResolvedException().getMessage());
+                .andExpect(resultReturned -> {
+                    assertInstanceOf(MemberException.class, resultReturned.getResolvedException());
+                    assertEquals(MemberErrorCode.NO_SESSION.getDeatil(), resultReturned.getResolvedException().getMessage());
                 });
         verify(authenticationAspect, times(1)).authenticate();
     }
+
     @Test
     @DisplayName("세션 ID 없음")
     void authenticateAOP_No_Session_ID() throws Exception {
         //given
-        SignUpForm form = new SignUpFormTestFixture().createAllFilledSignUpForm_Mock();
-        when(signUpService.signUp(any(Member.class))).thenReturn("회원가입 성공");
+        SignUpController.UpdateRequest req = UpdateRequestFixture.create();
+        when(signUpService.update(any(Member.class))).thenReturn(MemberFixture.createMemberWithId("UUID"));
 
-        final String cookieName = "CKIB4LV";
-        String encryptedEmail = encryption.encrypt(form.getEmail());
+        MvcResult result = LogInTestHelper.Login();
+        Cookie cookie = result.getResponse().getCookie(COOKIE_NAME);
 
         //when
-        ResultActions resultActions = mockMvc.perform(post(requestURL)
+        ResultActions resultActions = mockMvc.perform(put(requestURL)
                 .contentType(MediaType.APPLICATION_JSON)
-                .cookie(new Cookie(cookieName, encryptedEmail))
+                .cookie(cookie)
                 .sessionAttr("no session Id", "not UUID")
-                .content(mapper.writeValueAsString(form)));
+                .content(mapper.writeValueAsString(req)));
 
         //then
         resultActions.andExpect(status().isBadRequest())
-                .andExpect(result -> {
-                    assertNull(result.getRequest().getSession().getAttribute(encryptedEmail));
-                    assertTrue(result.getResolvedException() instanceof MemberException);
-                    assertEquals("로그인 정보가 서버에 존재하지 않습니다. 로그인이 필요합니다.", result.getResolvedException().getMessage());
+                .andExpect(resultReturned -> {
+                    assertInstanceOf(MemberException.class, resultReturned.getResolvedException());
+                    assertEquals(MemberErrorCode.NO_SESSION_ID.getDeatil(), resultReturned.getResolvedException().getMessage());
                 });
         verify(authenticationAspect, times(1)).authenticate();
     }

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/AlarmControllerTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/AlarmControllerTest.java
@@ -1,22 +1,30 @@
 package com.membercontext.memberAPI.web.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.membercontext.common.LogInTestHelper;
 import com.membercontext.common.fixture.web.AlarmRequestFixture;
+import com.membercontext.memberAPI.application.aop.authentication.AuthenticationAspect;
 import com.membercontext.memberAPI.application.service.AlarmService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.SpyBeans;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static com.membercontext.common.LogInTestHelper.TEST_COOKIE;
+import static com.membercontext.common.LogInTestHelper.TEST_SESSION;
 import static com.membercontext.memberAPI.web.controller.AlarmController.PUSH_ALARM_SEND_SUCCESS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AlarmController.class)
+@SpyBeans(@SpyBean(AuthenticationAspect.class))
 class AlarmControllerTest {
 
     @Autowired
@@ -28,6 +36,11 @@ class AlarmControllerTest {
     @Autowired
     private ObjectMapper mapper;
 
+    @BeforeEach
+    void setUp() throws Exception {
+        LogInTestHelper.Login();
+    }
+
     @Test
     void sendMessage() throws Exception {
         //given
@@ -35,6 +48,8 @@ class AlarmControllerTest {
 
         //when
         ResultActions result = mockMvc.perform(post("/sendMessage")
+                .cookie(TEST_COOKIE)
+                .session(TEST_SESSION)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(alarmForm)));
 

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/MemberInfoControllerTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/MemberInfoControllerTest.java
@@ -1,7 +1,9 @@
 package com.membercontext.memberAPI.web.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.membercontext.common.LogInTestHelper;
 import com.membercontext.common.fixture.domain.MemberFixture;
+import com.membercontext.memberAPI.application.aop.authentication.AuthenticationAspect;
+import com.membercontext.memberAPI.application.service.LogInService;
 import com.membercontext.memberAPI.application.service.MemberInfo.MemberInfoService;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 
@@ -10,11 +12,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.SpyBeans;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import static org.mockito.ArgumentMatchers.any;
+import static com.membercontext.common.LogInTestHelper.TEST_COOKIE;
+import static com.membercontext.common.LogInTestHelper.TEST_SESSION;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -22,17 +27,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @WebMvcTest(MemberInfoController.class)
+@SpyBeans(@SpyBean(AuthenticationAspect.class))
 class MemberInfoControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
-
 
     @MockBean
     private MemberInfoService memberInfoService;
 
     private static final String requestUrl = "/info/member";
 
+    @BeforeEach
+    void setUp() throws Exception {
+        LogInTestHelper.Login();
+    }
 
     @Test
     @DisplayName("아이디로 회원 정보 가져옴")
@@ -43,6 +52,8 @@ class MemberInfoControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(post(requestUrl)
+                .cookie(TEST_COOKIE)
+                .session(TEST_SESSION)
                 .contentType(MediaType.APPLICATION_JSON)
                 .param("id", memberToSearch.getId()));
 
@@ -55,7 +66,7 @@ class MemberInfoControllerTest {
                 .andExpect(jsonPath("$.data.name").value(memberToSearch.getName()))
                 .andExpect(jsonPath("$.data.phone").value(memberToSearch.getPhone()))
                 .andExpect(jsonPath("$.data.address").value(memberToSearch.getAddress()))
-                .andExpect(jsonPath("$.data.isLocationServiceEnabled").value(memberToSearch.isLocationServiceEnabled()))
+                .andExpect(jsonPath("$.data.locationServiceEnabled").value(memberToSearch.isLocationServiceEnabled()))
                 .andExpect(jsonPath("$.data.point").value(memberToSearch.getPoint()));
     }
 }


### PR DESCRIPTION
### 변경사항
- 조금씩 건드려 놨던 로컬 파일들을 시간되는 한 마무리 중입니다. 커밋 패널에서 최근 수정사항을 찾기가 조금 어려워져 DDD로 구조 변경을 하며 한번에 하나씩 하는 습관을 가지려고 수정되어 있는 것들을 시간날때 조금씩 마무리하려고 합니다.
- 이후 필터로 변경할까 하고 있지만 현재까지 AOP로 로그인 인증을 확인하고 있었는데 적용되고 있지 않아서 수정하였습니다.
- RestController 태그를 붙여주어야 하는데 Controller로 붙여 놓은 것들이 있어서 변경하였습니다.
  - String을 주는 경우에는 오류가 났었는데 스프링 타임리프 라이브러리를 안 지웠나라고 생각했는데 이거였군요..
  - ResponseEntity를 내려주는 경우에는 다행히 제대로 동작해서 문제가 없었던 것 같습니다. 확실히 하기위해 Member MS에서는 모두 변경했습니다. 다른 MS도 수정사항때 변경하겠습니다!