### PR TITLE
[48-member-도메인-영역-캡슐화]

### DIFF
--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/AlarmService.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/AlarmService.java
@@ -18,8 +18,10 @@ public class AlarmService {
 
     private static final int radius = 40;
 
-    public void sendPushMessage(AlarmController.AlarmRequest alarmForm) {
-        List<Member> membersToPush = memberRepository.findNearByMember(alarmForm.getX(), alarmForm.getY(), radius);
+    public void sendPushMessage(AlarmController.AlarmRequest alarmRequest) {
+        //fixme: Member 일때랑 여러명의 맴버일때랑 어떻게 캡슐화를 해야 할지 고민이 됩니다.
+        //       이 부분은 하나의 맴버에 국한 된게 아니기도 하고 또, Help 도메인과 협력을 하는 부분이라 응용계층이 적합하지 않을까 합니다. 괜찮을까요?
+        List<Member> membersToPush = memberRepository.findNearByMember(alarmRequest.getX(), alarmRequest.getY(), radius);
         if (membersToPush.isEmpty()) {
             return;
         }
@@ -27,6 +29,6 @@ public class AlarmService {
                 .map(member -> member.getMemberLocation().getFcmToken())
                 .toList();
 
-        fireBaseCloudMessageClient.sendMultipleMessages(tokens, alarmForm.getTitle(), alarmForm.getMessage());
+        fireBaseCloudMessageClient.sendMultipleMessages(tokens, alarmRequest.getTitle(), alarmRequest.getMessage());
     }
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/LogInService.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/LogInService.java
@@ -17,13 +17,9 @@ public class LogInService {
     private final MemberRepository memberRepository;
     private final JavaCryptoUtil javaCryptoUtil;
 
-    public Member logIn(String email, String password){
+    public Member logIn(String email, String password) {
         Member member = memberRepository.findByEmail(email);
-        if(member.getPassword().equals(javaCryptoUtil.encrypt(password))){
-            return member;
-        }else{
-            throw new MemberException(INVALID_PASSWORD);
-        }
+        return member.logIn(javaCryptoUtil, password);
     }
 
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberInfo/MemberInfoServiceImpl.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberInfo/MemberInfoServiceImpl.java
@@ -17,9 +17,11 @@ public class MemberInfoServiceImpl implements MemberInfoService {
     @Override
     public Member getMemberInfo(String id) {
         Member member = memberRepository.findById(id);
+        //fixme: 조회에 대한 책임도 응용계층에서 처리하게 되는지 궁금합니다. 이 로직을 Member에 넣기도 어려울 것 같아서요.
         if (member == null) {
             throw new MemberException(NOT_EXITING_USER);
         }
         return member;
+
     }
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberWriteSerivces/Impl/MemberWriteServiceImpl.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberWriteSerivces/Impl/MemberWriteServiceImpl.java
@@ -1,8 +1,7 @@
-package com.membercontext.memberAPI.application.service.SignUpSerivces.Impl;
+package com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl;
 
-import com.membercontext.memberAPI.application.aop.log.Log;
 import com.membercontext.memberAPI.application.repository.MemberRepository;
-import com.membercontext.memberAPI.application.service.SignUpSerivces.SignUpService;
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.MemberWriteService;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
 import jakarta.transaction.Transactional;
@@ -11,17 +10,15 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class SignUpServiceImpl implements SignUpService {
+public class MemberWriteServiceImpl implements MemberWriteService {
 
     private final MemberRepository memberRepository;
-    private final JavaCryptoUtil encryption;
+    private final JavaCryptoUtil javaCryptoUtil;
 
     @Override
     @Transactional
     public String signUp(Member member) {
-        String encryptedPassword = encryption.encrypt(member.getPassword()); // 초기화 백터(IV) 미적용
-        member.encryptPassword(encryptedPassword);
-        return memberRepository.save(member);
+        return memberRepository.save(member.signUp(javaCryptoUtil));
     }
 
     @Override
@@ -35,7 +32,6 @@ public class SignUpServiceImpl implements SignUpService {
     public void delete(String id) {
         memberRepository.delete(id);
     }
-
 }
 
 

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberWriteSerivces/MemberWriteService.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberWriteSerivces/MemberWriteService.java
@@ -1,12 +1,13 @@
-package com.membercontext.memberAPI.application.service.SignUpSerivces;
+package com.membercontext.memberAPI.application.service.MemberWriteSerivces;
 
 import com.membercontext.memberAPI.domain.entity.member.Member;
 
 
-public interface SignUpService {
+public interface MemberWriteService {
     String signUp(Member member);
 
     Member update(Member updatingMember);
 
     void delete(String id);
+
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/TrackService.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/TrackService.java
@@ -15,14 +15,14 @@ public class TrackService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void saveCurrentLocation(TrackController.TrackRequest form, String memberId) {
+    public void startLocationTracking(TrackController.TrackRequest request, String memberId) {
         Member member = memberRepository.findById(memberId);
-        member.updateLocation(form);
+        member.startLocationTracking(request);
     }
 
     @Transactional
-    public void saveToken(String token, String memberId) {
+    public void enablePushAlarm(String token, String memberId) {
         Member member = memberRepository.findById(memberId);
-        member.startLocationAlarm(token);
+        member.enablePushAlarm(token);
     }
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/SignUpController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/SignUpController.java
@@ -1,7 +1,7 @@
 package com.membercontext.memberAPI.web.controller;
 
 import com.membercontext.memberAPI.application.aop.authentication.NoAuthentication;
-import com.membercontext.memberAPI.application.service.SignUpSerivces.SignUpService;
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.MemberWriteService;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.memberAPI.web.controller.dto.DefaultHTTPResponse;
 import jakarta.validation.constraints.Email;
@@ -9,7 +9,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/sign-in")
 public class SignUpController {
 
-    private final SignUpService signUpService;
+    private final MemberWriteService signUpService;
 
     public static final String MEMBER_SIGN_UP_SUCCESS_MESSAGE = "회원가입 성공";
     public static final String MEMBER_UPDATE_SUCCESS_MESSAGE = "회원 수정 성공";
@@ -28,6 +27,8 @@ public class SignUpController {
     @NoAuthentication
     public ResponseEntity<DefaultHTTPResponse<String>> signIn(@Validated @RequestBody SignUpRequest signUpRequest) {
         String id = signUpService.signUp(Member.from(signUpRequest));
+        //fixme: from은 도메인 로직인데 여기서 사용하는 것도 레이어의 경계에 맞지 않게 사용하는게 아닐까요?
+        //       이 변환을 도메인의 member.signUp 로직에 추가를 해야하는게 아닐까 생각이 들었습니다.
         return ResponseEntity.ok(new DefaultHTTPResponse<>(MEMBER_SIGN_UP_SUCCESS_MESSAGE, id));
     }
 

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TrackController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/TrackController.java
@@ -29,7 +29,7 @@ public class TrackController {
     @PostMapping("/track")
     public ResponseEntity<DefaultHTTPResponse<Void>> track(@CookieValue(value = COOKIE_NAME) String cookieValue, HttpServletRequest request, @Validated @RequestBody TrackRequest trackRequest) {
         String email = (String) request.getSession().getAttribute(cookieValue);
-        trackService.saveCurrentLocation(trackRequest, email);
+        trackService.startLocationTracking(trackRequest, email);
 
         return ResponseEntity.ok().body(new DefaultHTTPResponse<>(LOCATION_TRACK_ONGOING));
     }
@@ -37,7 +37,7 @@ public class TrackController {
     @PostMapping(value = "/token", consumes = "application/json")
     public ResponseEntity<DefaultHTTPResponse<Void>> token(@CookieValue(value = COOKIE_NAME) String cookieValue, HttpServletRequest request, @Validated @RequestBody FCMTokenRequest fcmTokenRequest) {
         String id = (String) request.getSession().getAttribute(cookieValue);
-        trackService.saveToken(fcmTokenRequest.getToken(), id);
+        trackService.enablePushAlarm(fcmTokenRequest.getToken(), id);
 
         return ResponseEntity.ok().body(new DefaultHTTPResponse<>(FCM_TOKEN_REGISTERED));
     }

--- a/member-context/src/test/java/com/membercontext/common/stub/test/MemberJPARepositoryStubIntegratedTest.java
+++ b/member-context/src/test/java/com/membercontext/common/stub/test/MemberJPARepositoryStubIntegratedTest.java
@@ -232,13 +232,13 @@ class MemberJPARepositoryStubIntegratedTest {
             //given
             Member member = MemberFixture.create();
             TrackController.TrackRequest targetLocation = TrackRequestFixture.createRequestWithDifferentLocation(0, 0);
-            member.updateLocation(targetLocation);
+            member.startLocationTracking(targetLocation);
             db.save(member);
             stub.save(member);
 
             Member memberNearBy = MemberFixture.createMemberWithDifferentEmail("memberNearBy@test.com");
             TrackController.TrackRequest request = TrackRequestFixture.createRequestWithDifferentLocation(0, 0.002);
-            memberNearBy.updateLocation(request);
+            memberNearBy.startLocationTracking(request);
 
             stub.save(memberNearBy);
             db.save(memberNearBy);
@@ -273,13 +273,13 @@ class MemberJPARepositoryStubIntegratedTest {
             //given
             Member member = MemberFixture.create();
             TrackController.TrackRequest targetLocation = TrackRequestFixture.createRequestWithDifferentLocation(0, 0);
-            member.updateLocation(targetLocation);
+            member.startLocationTracking(targetLocation);
             db.save(member);
             stub.save(member);
 
             Member memberFar = MemberFixture.createMemberWithDifferentEmail("memberFar@test.com");
             TrackController.TrackRequest request = TrackRequestFixture.createRequestWithDifferentLocation(400, 400);
-            memberFar.updateLocation(request);
+            memberFar.startLocationTracking(request);
 
 
             stub.save(memberFar);

--- a/member-context/src/test/java/com/membercontext/common/stub/test/MemberSpringJPARespotiroyStubIntegratedTest.java
+++ b/member-context/src/test/java/com/membercontext/common/stub/test/MemberSpringJPARespotiroyStubIntegratedTest.java
@@ -15,7 +15,6 @@ import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -167,12 +166,12 @@ public class MemberSpringJPARespotiroyStubIntegratedTest {
         void findNearByMember() {
             //given
             TrackController.TrackRequest targetLocation = TrackRequestFixture.createRequestWithDifferentLocation(0, 0);
-            dbMember.updateLocation(targetLocation);
-            stubMember.updateLocation(targetLocation);
+            dbMember.startLocationTracking(targetLocation);
+            stubMember.startLocationTracking(targetLocation);
 
             Member memberNearBy = MemberFixture.createMemberWithDifferentEmail("memberNearBy@test.com");
             TrackController.TrackRequest request = TrackRequestFixture.createRequestWithDifferentLocation(0, 0.002);
-            memberNearBy.updateLocation(request);
+            memberNearBy.startLocationTracking(request);
 
             stub.save(memberNearBy);
             memberSpringJPARepository.save(memberNearBy);
@@ -203,13 +202,13 @@ public class MemberSpringJPARespotiroyStubIntegratedTest {
         @DisplayName("findNearByMember - 떨어져 있는 맴버.")
         void findNearByMember_OtherFar() {
             TrackController.TrackRequest targetLocation = TrackRequestFixture.createRequestWithDifferentLocation(0, 0);
-            dbMember.updateLocation(targetLocation);
-            stubMember.updateLocation(targetLocation);
+            dbMember.startLocationTracking(targetLocation);
+            stubMember.startLocationTracking(targetLocation);
 
             //given
             Member memberFar = MemberFixture.createMemberWithDifferentEmail("MemberFar@test.com");
             TrackController.TrackRequest request = TrackRequestFixture.createRequestWithDifferentLocation(400, 400);
-            memberFar.updateLocation(request);
+            memberFar.startLocationTracking(request);
 
             stub.save(memberFar);
             memberSpringJPARepository.save(memberFar);

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/aop/authentication/AuthenticationAspectTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/aop/authentication/AuthenticationAspectTest.java
@@ -6,7 +6,7 @@ import com.membercontext.common.fixture.domain.MemberFixture;
 import com.membercontext.common.fixture.web.crud.UpdateRequestFixture;
 import com.membercontext.memberAPI.application.exception.member.MemberErrorCode;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
-import com.membercontext.memberAPI.application.service.SignUpSerivces.SignUpService;
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.MemberWriteService;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
 import com.membercontext.memberAPI.web.controller.SignUpController;
@@ -47,7 +47,7 @@ class AuthenticationAspectTest {
     private AuthenticationAspect authenticationAspect; //이게 빈으로 있어야 AOP 작동.
 
     @MockBean
-    private SignUpService signUpService;
+    private MemberWriteService signUpService;
 
     private final String requestURL = "/sign-in";
 

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/exception/ExceptionControllerTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/exception/ExceptionControllerTest.java
@@ -3,7 +3,7 @@ package com.membercontext.memberAPI.application.exception;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.membercontext.common.fixture.web.crud.SignUpRequestFixture;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
-import com.membercontext.memberAPI.application.service.SignUpSerivces.SignUpService;
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.MemberWriteService;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.memberAPI.web.controller.SignUpController;
 import org.junit.jupiter.api.DisplayName;
@@ -36,7 +36,7 @@ class ExceptionControllerTest {
     private ObjectMapper mapper;
 
     @MockBean
-    private SignUpService signUpService;
+    private MemberWriteService signUpService;
 
     @Test
     @DisplayName("MemberException 발생 예시")

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/service/AlarmServiceTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/service/AlarmServiceTest.java
@@ -49,11 +49,11 @@ class AlarmServiceTest {
             TrackController.TrackRequest req = TrackRequestFixture.createRequestWithDifferentLocation(0, 0);
 
             Member member1 = MemberFixture.createMemberWithId("UUID");
-            member1.updateLocation(req);
+            member1.startLocationTracking(req);
             memberRepository.save(member1);
 
             Member member2 = MemberFixture.createMemberWithId("UUID2");
-            member2.updateLocation(req);
+            member2.startLocationTracking(req);
             memberRepository.save(member2);
 
             //when

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/service/TrackServiceTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/service/TrackServiceTest.java
@@ -30,14 +30,14 @@ class TrackServiceTest {
 
     @Test
     @DisplayName("현재 위치 저장")
-    void saveCurrentLocation() {
+    void startLocationTracking() {
         // given
         Member member = MemberFixture.create();
         String id = memberRepository.save(member);
         TrackController.TrackRequest form = TrackRequestFixture.create();
 
         //when
-        sut.saveCurrentLocation(form, id);
+        sut.startLocationTracking(form, id);
 
         // then
         Member updatedMember = memberRepository.findById(id);
@@ -48,14 +48,14 @@ class TrackServiceTest {
 
     @Test
     @DisplayName("FCM 토큰 저장")
-    void saveToken() {
+    void enablePushAlarm() {
         // given
         String token = "token";
         Member member = MemberFixture.create();
         String id = memberRepository.save(member);
 
         //when
-        sut.saveToken(token, id);
+        sut.enablePushAlarm(token, id);
 
         // then
         Member updatedMember = memberRepository.findById(id);

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/service/signUp/MemberWriteServiceImplTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/service/signUp/MemberWriteServiceImplTest.java
@@ -4,7 +4,7 @@ import com.membercontext.common.stub.JavaCryptoUtilMockStub;
 import com.membercontext.common.stub.MemberJPARepositoryStub;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import com.membercontext.memberAPI.application.repository.MemberRepository;
-import com.membercontext.memberAPI.application.service.SignUpSerivces.Impl.SignUpServiceImpl;
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl.MemberWriteServiceImpl;
 
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.common.fixture.domain.MemberFixture;
@@ -22,10 +22,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
 @ExtendWith(MockitoExtension.class)
-class SignUpServiceImplTest {
+class MemberWriteServiceImplTest {
 
     @InjectMocks
-    private SignUpServiceImpl sut;
+    private MemberWriteServiceImpl sut;
 
     @Spy
     private MemberRepository memberRepository = new MemberJPARepositoryStub();

--- a/member-context/src/test/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepositoryTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepositoryTest.java
@@ -6,7 +6,6 @@ import com.membercontext.common.fixture.web.TrackRequestFixture;
 import com.membercontext.common.stub.MemberSpringJPARepositoryStub;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import com.membercontext.memberAPI.domain.entity.member.Member;
-import com.membercontext.memberAPI.web.controller.TrackController;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -205,10 +204,10 @@ class MemberJPARepositoryTest {
             int radius = 500; // 500km
 
             Member memberAt0 = MemberFixture.create();
-            memberAt0.updateLocation(TrackRequestFixture.createRequestWithDifferentLocation(x, y));
+            memberAt0.startLocationTracking(TrackRequestFixture.createRequestWithDifferentLocation(x, y));
 
             Member memberNear = MemberFixture.createMemberWithDifferentEmail("nearMember@test.com");
-            memberNear.updateLocation(TrackRequestFixture.createRequestWithDifferentLocation(0, 0.002));
+            memberNear.startLocationTracking(TrackRequestFixture.createRequestWithDifferentLocation(0, 0.002));
 
             memberSpringJPARepository.save(memberAt0);
             memberNear = memberSpringJPARepository.save(memberNear);
@@ -247,10 +246,10 @@ class MemberJPARepositoryTest {
             int radius = 1;
 
             Member memberAt0 = MemberFixture.create();
-            memberAt0.updateLocation(TrackRequestFixture.createRequestWithDifferentLocation(x, y));
+            memberAt0.startLocationTracking(TrackRequestFixture.createRequestWithDifferentLocation(x, y));
 
             Member memberFar = MemberFixture.createMemberWithDifferentEmail("farMember@test.com");
-            memberFar.updateLocation(TrackRequestFixture.createRequestWithDifferentLocation(300, 300));
+            memberFar.startLocationTracking(TrackRequestFixture.createRequestWithDifferentLocation(300, 300));
 
             memberSpringJPARepository.save(memberAt0);
             memberFar = memberSpringJPARepository.save(memberFar);

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/SignUpControllerTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/SignUpControllerTest.java
@@ -5,17 +5,14 @@ import com.membercontext.common.LogInTestHelper;
 import com.membercontext.common.fixture.web.crud.SignUpRequestFixture;
 import com.membercontext.common.fixture.web.crud.UpdateRequestFixture;
 import com.membercontext.memberAPI.application.aop.authentication.AuthenticationAspect;
-import com.membercontext.memberAPI.application.service.LogInService;
-import com.membercontext.memberAPI.application.service.SignUpSerivces.SignUpService;
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.MemberWriteService;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 
-import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.MockBeans;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.mock.mockito.SpyBeans;
 import org.springframework.http.MediaType;
@@ -44,7 +41,7 @@ public class SignUpControllerTest {
     private ObjectMapper mapper;
 
     @MockBean
-    private SignUpService signUpService;
+    private MemberWriteService signUpService;
 
     @BeforeEach
     void setUp() throws Exception {

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/dto/request/signUp/SignUpRequestTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/dto/request/signUp/SignUpRequestTest.java
@@ -2,7 +2,7 @@ package com.membercontext.memberAPI.web.controller.dto.request.signUp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.membercontext.common.fixture.web.crud.SignUpRequestFixture;
-import com.membercontext.memberAPI.application.service.SignUpSerivces.Impl.SignUpServiceImpl;
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl.MemberWriteServiceImpl;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.memberAPI.web.controller.SignUpController;
 
@@ -32,7 +32,7 @@ class SignUpRequestTest {
     private ObjectMapper mapper;
 
     @MockBean
-    private SignUpServiceImpl signUpService;
+    private MemberWriteServiceImpl signUpService;
 
     private final String requestURL = "/sign-in";
 

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/dto/request/signUp/UpdateRequestTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/dto/request/signUp/UpdateRequestTest.java
@@ -1,7 +1,7 @@
 package com.membercontext.memberAPI.web.controller.dto.request.signUp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.membercontext.memberAPI.application.service.SignUpSerivces.Impl.SignUpServiceImpl;
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl.MemberWriteServiceImpl;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.memberAPI.web.controller.SignUpController;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +28,7 @@ class UpdateRequestTest {
     @Autowired
     private ObjectMapper mapper;
     @MockBean
-    private SignUpServiceImpl signUpService;
+    private MemberWriteServiceImpl signUpService;
 
     private final String requestURL = "/sign-in";
     private SignUpController.UpdateRequest req;


### PR DESCRIPTION
### 변경사항
- 도메인 서비스를 만들려 했지만, 복잡하지 않다고 느껴져 일단 캡슐화를 진행하였습니다. 
  - Q1. 응용 서비스는 에그리거트보다 바운디드 컨텍스트간(애그리거트 루트)의 협력이 필요할 때 사용될 것 같습니다. (맞을까요??)
    - AlarmService가 이런 경우가 아닐까 합니다. ([링크](https://github.com/f-lab-edu/check-in-before-leaving/blob/683c0b0c7cef2b1bfa7110310d7aa33d2b29ce42/member-context/src/main/java/com/membercontext/memberAPI/application/service/AlarmService.java))
  - Q2. 도메인 서비스를 만들 정도의 복잡성이라면, 현재로서는 MemberLocation이나 혹시 미래에 Member에 생길 VO들과의 비즈니스가 복잡해진다면 만들수 있을것 같은데, 이런 접근이 맞나요? 
  - Q3. 현재로서도 Member 엔티티의 signUp, logIn등의 로직을 도메인이 아닌 도메인 서비스에 두고 싶다면 MemberService이렇게 둘 수도 있는 건가요? 
  - Q4. 만약 3번이 가능하다면 MemberLocation과의 비즈니스를 도메인 서비스로 만들때는 MemberService말고 MemberLocationService라는 새로운 도메인 서비스 파일을 만들어서 제작해도 되나요? 아니면 (도메인은 하나의 도메인 서비스를 가져야 한다고 들은 것 같아서 질문 드립니다.)

- 다른 부분에서도 질문이 생겨 commit으로 정리해 두었습니다.
  - 레이어 관련 질문 ([링크](https://github.com/f-lab-edu/check-in-before-leaving/blob/769c80e9ea801d63b9e1bc7d3282eb13b9f0a440/member-context/src/main/java/com/membercontext/memberAPI/web/controller/SignUpController.java))
  - 기타 질문들 (683c0b0c7cef2b1bfa7110310d7aa33d2b29ce42) 
