### PR TITLE
[Hotfix-07-1-도메인서비스-적용]

### DIFF
--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/LogInService.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/LogInService.java
@@ -3,6 +3,7 @@ package com.membercontext.memberAPI.application.service;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.domain.entity.member.Member;
+import com.membercontext.memberAPI.domain.entity.member.MemberService;
 import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,12 +15,10 @@ import static com.membercontext.memberAPI.application.exception.member.MemberErr
 @RequiredArgsConstructor
 public class LogInService {
 
-    private final MemberRepository memberRepository;
-    private final JavaCryptoUtil javaCryptoUtil;
+    private final MemberService memberService;
 
     public Member logIn(String email, String password) {
-        Member member = memberRepository.findByEmail(email);
-        return member.logIn(javaCryptoUtil, password);
+        return memberService.logIn(email, password);
     }
 
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberInfo/MemberInfoServiceImpl.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberInfo/MemberInfoServiceImpl.java
@@ -3,6 +3,7 @@ package com.membercontext.memberAPI.application.service.MemberInfo;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.domain.entity.member.Member;
+import com.membercontext.memberAPI.domain.entity.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,16 +13,10 @@ import static com.membercontext.memberAPI.application.exception.member.MemberErr
 @RequiredArgsConstructor
 public class MemberInfoServiceImpl implements MemberInfoService {
 
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     @Override
     public Member getMemberInfo(String id) {
-        Member member = memberRepository.findById(id);
-        //fixme: 조회에 대한 책임도 응용계층에서 처리하게 되는지 궁금합니다. 이 로직을 Member에 넣기도 어려울 것 같아서요.
-        if (member == null) {
-            throw new MemberException(NOT_EXITING_USER);
-        }
-        return member;
-
+        return memberService.findOneMember(id);
     }
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberWriteSerivces/Impl/MemberWriteApplication.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/MemberWriteSerivces/Impl/MemberWriteApplication.java
@@ -1,36 +1,34 @@
 package com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl;
 
-import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.application.service.MemberWriteSerivces.MemberWriteService;
 import com.membercontext.memberAPI.domain.entity.member.Member;
-import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
+import com.membercontext.memberAPI.domain.entity.member.MemberService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class MemberWriteServiceImpl implements MemberWriteService {
+public class MemberWriteApplication implements MemberWriteService {
 
-    private final MemberRepository memberRepository;
-    private final JavaCryptoUtil javaCryptoUtil;
+    private final MemberService memberService;
 
     @Override
     @Transactional
     public String signUp(Member member) {
-        return memberRepository.save(member.signUp(javaCryptoUtil));
+        return memberService.signUp(member);
     }
 
     @Override
     @Transactional
     public Member update(Member updatingMember) {
-        return memberRepository.update(updatingMember);
+        return memberService.update(updatingMember);
     }
 
     @Override
     @Transactional
     public void delete(String id) {
-        memberRepository.delete(id);
+        memberService.delete(id);
     }
 }
 

--- a/member-context/src/main/java/com/membercontext/memberAPI/application/service/TrackService.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/application/service/TrackService.java
@@ -3,6 +3,7 @@ package com.membercontext.memberAPI.application.service;
 
 import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.domain.entity.member.Member;
+import com.membercontext.memberAPI.domain.entity.member.MemberService;
 import com.membercontext.memberAPI.web.controller.TrackController;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,18 +12,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class TrackService {
-
-    private final MemberRepository memberRepository;
+    
+    private final MemberService memberService;
 
     @Transactional
     public void startLocationTracking(TrackController.TrackRequest request, String memberId) {
-        Member member = memberRepository.findById(memberId);
-        member.startLocationTracking(request);
+        memberService.startLocationTracking(memberId, request);
     }
 
     @Transactional
     public void enablePushAlarm(String token, String memberId) {
-        Member member = memberRepository.findById(memberId);
-        member.enablePushAlarm(token);
+        memberService.enablePushAlarm(token, memberId);
     }
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/Member.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/Member.java
@@ -11,7 +11,6 @@ import lombok.*;
 
 
 import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.LOCATION_SERVICE_NOT_PERMITTED;
-import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.NOT_EXITING_USER;
 
 @Entity
 @Getter
@@ -47,16 +46,9 @@ public class Member {
 
     private Long point;
 
-
     //CRUD
     //SignUp
-    public Member signUp(JavaCryptoUtil encryption) {
-        this.encryptPassword(encryption);
-        return this;
-    }
-
-    private void encryptPassword(JavaCryptoUtil javaCryptoUtil) {
-        String encryptedPassword = javaCryptoUtil.encrypt(this.password);
+    protected void encryptPassword(String encryptedPassword) {
         this.password = encryptedPassword;
     }
 
@@ -73,7 +65,7 @@ public class Member {
     }
 
     // Update
-    public void update(Member updatingMember) {
+    public Member update(Member updatingMember) { //public
         this.email = updatingMember.getEmail();
         this.password = updatingMember.getPassword();
         this.name = updatingMember.getName();
@@ -81,6 +73,7 @@ public class Member {
         this.address = updatingMember.getAddress();
         this.locationServiceEnabled = updatingMember.isLocationServiceEnabled();
         this.point = updatingMember.getPoint();
+        return this;
     }
 
     public static Member from(SignUpController.UpdateRequest req) {
@@ -115,7 +108,7 @@ public class Member {
         if (!this.isLocationServiceEnabled()) {
             throw new MemberException(LOCATION_SERVICE_NOT_PERMITTED);
         }
-        this.memberLocation = this.memberLocation.addLocation(form.getLatitude(), form.getLongitude(), form.getTimestamp());
+        this.memberLocation = this.memberLocation.updateLocation(form.getLatitude(), form.getLongitude(), form.getTimestamp());
     }
 
     // Push Alarm

--- a/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/MemberLocation.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/MemberLocation.java
@@ -39,7 +39,7 @@ public final class MemberLocation {
         this.fcmToken = fcmToken;
     }
 
-    public MemberLocation addLocation(Double latitude, Double longitude, LocalDateTime timestamp) {
+    public MemberLocation updateLocation(Double latitude, Double longitude, LocalDateTime timestamp) {
         if (latitude == null || longitude == null || timestamp == null) {
             throw new MemberException(NO_VALUE);
         }
@@ -75,7 +75,7 @@ public final class MemberLocation {
     }
     //todo: FCM token도 nullable 하도록 변경
 //
-//    public Optional<String> getFcmToken(Member member) {
+//    public Optional<String> getFcmToken(Member member) {.
 //        return Optional.ofNullable(this.fcmToken);
 //    }
 

--- a/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/MemberService.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/MemberService.java
@@ -1,0 +1,62 @@
+package com.membercontext.memberAPI.domain.entity.member;
+
+import com.membercontext.memberAPI.application.exception.member.MemberException;
+import com.membercontext.memberAPI.application.repository.MemberRepository;
+import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
+import com.membercontext.memberAPI.web.controller.TrackController;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.NOT_EXITING_USER;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    // Member와 같은 패키지에 있어야 함.
+    private final MemberRepository memberRepository;
+    private final JavaCryptoUtil javaCryptoUtil;
+
+    public String signUp(Member member) {
+        String encryptedPassword = javaCryptoUtil.encrypt(member.getPassword());
+        member.encryptPassword(encryptedPassword);
+        return memberRepository.save(member);
+    }
+
+    public Member update(Member updatingMember) {
+        Member member = memberRepository.findById(updatingMember.getId());
+        return member.update(updatingMember);
+    }
+
+    public void delete(String id) {
+        memberRepository.delete(id);
+    }
+
+    //Read
+    public Member findOneMember(String id) {
+        Member member = memberRepository.findById(id);
+
+        if (member == null) {
+            throw new MemberException(NOT_EXITING_USER);
+        }
+        return member;
+    }
+
+    //LogIn
+    public Member logIn(String email, String password) {
+        Member member = memberRepository.findByEmail(email);
+        return member.logIn(javaCryptoUtil, password);
+    }
+
+    //Track
+    public void startLocationTracking(String memberId, TrackController.TrackRequest request) {
+        Member member = memberRepository.findById(memberId);
+        member.startLocationTracking(request);
+    }
+
+    public void enablePushAlarm(String token, String memberId) {
+        Member member = memberRepository.findById(memberId);
+        member.enablePushAlarm(token);
+    }
+
+
+}

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/service/LogInServiceTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/service/LogInServiceTest.java
@@ -1,10 +1,12 @@
 package com.membercontext.memberAPI.application.service;
 
 import com.membercontext.common.fixture.domain.MemberFixture;
+import com.membercontext.common.stub.JavaCryptoUtilMockStub;
 import com.membercontext.common.stub.MemberJPARepositoryStub;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.domain.entity.member.Member;
+import com.membercontext.memberAPI.domain.entity.member.MemberService;
 import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,19 +26,16 @@ class LogInServiceTest {
     @InjectMocks
     private LogInService sut;
 
-    @Spy
-    private MemberRepository memberRepository = new MemberJPARepositoryStub();
-
     @Mock
-    private JavaCryptoUtil javaCryptoUtil;
+    private MemberService memberService;
 
     @Test
     @DisplayName("로그인 성공")
     void logIn() {
         //given
-        Member member = MemberFixture.create();
-        String id = memberRepository.save(member);
-        when(javaCryptoUtil.encrypt(member.getPassword())).thenReturn(member.getPassword());
+        String id = "uuid";
+        Member member = MemberFixture.createMemberWithId(id);
+        when(memberService.logIn(member.getEmail(), member.getPassword())).thenReturn(member);
 
         //when
         Member logInMember = sut.logIn(member.getEmail(), member.getPassword());
@@ -48,22 +47,6 @@ class LogInServiceTest {
         assertEquals(member.getPhone(), logInMember.getPhone());
         assertEquals(member.getAddress(), logInMember.getAddress());
         assertEquals(member.getPoint(), logInMember.getPoint());
-    }
-
-    @Test
-    @DisplayName("로그인 실패 - 비밀번호 불일치")
-    void logIn_PasswordInvalid() {
-        //given
-        Member member = MemberFixture.create();
-        String id = memberRepository.save(member);
-        when(javaCryptoUtil.encrypt(member.getPassword())).thenReturn(null);
-
-        //when
-        Exception exception = assertThrows(MemberException.class, () -> sut.logIn(member.getEmail(), member.getPassword()));
-
-        //then
-        assertEquals(exception.getClass(), MemberException.class);
-        assertEquals(exception.getMessage(), INVALID_PASSWORD.getDeatil());
     }
 
 }

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/service/MemberInfoServiceImplTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/service/MemberInfoServiceImplTest.java
@@ -7,39 +7,41 @@ import com.membercontext.memberAPI.application.exception.member.MemberException;
 import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.application.service.MemberInfo.MemberInfoServiceImpl;
 import com.membercontext.memberAPI.domain.entity.member.Member;
+import com.membercontext.memberAPI.domain.entity.member.MemberService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MemberInfoServiceImplTest {
 
     @InjectMocks
-    private MemberInfoServiceImpl memberInfoService;
+    private MemberInfoServiceImpl sut;
 
-    @Spy
-    private MemberRepository memberRepository = new MemberJPARepositoryStub();
+    @Mock
+    private MemberService memberService;
 
 
     @Test
     @DisplayName("아이디로 회원 정보 가져옴")
     void getMemberInfo() {
         //given
-        Member memberToSearch = MemberFixture.create();
-        String id = memberRepository.save(memberToSearch);
+        String id = "uuid";
+        Member memberToSearch = MemberFixture.createMemberWithId(id);
+        when(memberService.findOneMember(id)).thenReturn(memberToSearch);
 
         //when
-        Member memberReturned = memberInfoService.getMemberInfo(id);
+        Member memberReturned = sut.getMemberInfo(id);
 
         //then
         assertEquals(id, memberReturned.getId());
@@ -52,17 +54,4 @@ class MemberInfoServiceImplTest {
         assertEquals(memberToSearch.getPoint(), memberReturned.getPoint());
     }
 
-    @Test
-    @DisplayName("아이디로 회원 정보 가져옴 - 회원이 없는 경우")
-    void getMemberInfo_NotExistingUser() {
-        //given
-        String id = "notExistingId";
-
-        //when
-        Exception exception = assertThrows(Exception.class, () -> memberInfoService.getMemberInfo(id));
-
-        //then
-        assertEquals(exception.getClass(), MemberException.class);
-        assertEquals(exception.getMessage(), MemberErrorCode.NOT_EXITING_USER.getDeatil());
-    }
 }

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/service/TrackServiceTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/service/TrackServiceTest.java
@@ -2,21 +2,21 @@ package com.membercontext.memberAPI.application.service;
 
 import com.membercontext.common.fixture.domain.MemberFixture;
 import com.membercontext.common.fixture.web.TrackRequestFixture;
-import com.membercontext.common.stub.MemberJPARepositoryStub;
-import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 
+import com.membercontext.memberAPI.domain.entity.member.MemberService;
 import com.membercontext.memberAPI.web.controller.TrackController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 
-import org.mockito.Spy;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -25,41 +25,36 @@ class TrackServiceTest {
     @InjectMocks
     private TrackService sut;
 
-    @Spy
-    private MemberRepository memberRepository = new MemberJPARepositoryStub();
+    @Mock
+    private MemberService memberService;
 
     @Test
     @DisplayName("현재 위치 저장")
     void startLocationTracking() {
         // given
-        Member member = MemberFixture.create();
-        String id = memberRepository.save(member);
-        TrackController.TrackRequest form = TrackRequestFixture.create();
+        String id = "uuid";
+        Member member = MemberFixture.createMemberWithId(id);
+        TrackController.TrackRequest request = TrackRequestFixture.create();
 
         //when
-        sut.startLocationTracking(form, id);
+        sut.startLocationTracking(request, id);
 
         // then
-        Member updatedMember = memberRepository.findById(id);
-        assertEquals(updatedMember.getMemberLocation().getLongitude(updatedMember).get(), form.getLongitude());
-        assertEquals(updatedMember.getMemberLocation().getLatitude(updatedMember).get(), form.getLatitude());
-        assertEquals(updatedMember.getMemberLocation().getTimestamp(updatedMember).get(), form.getTimestamp());
+        verify(memberService).startLocationTracking(id, request);
     }
 
     @Test
     @DisplayName("FCM 토큰 저장")
     void enablePushAlarm() {
         // given
+        String id = "uuid";
         String token = "token";
-        Member member = MemberFixture.create();
-        String id = memberRepository.save(member);
+        Member member = MemberFixture.createMemberWithId(id);
 
         //when
         sut.enablePushAlarm(token, id);
 
         // then
-        Member updatedMember = memberRepository.findById(id);
-        assertThat(updatedMember.getMemberLocation().getFcmToken()).isEqualTo(token);
+        verify(memberService).enablePushAlarm(token, id);
     }
-
 }

--- a/member-context/src/test/java/com/membercontext/memberAPI/application/service/signUp/MemberWriteApplicationTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/application/service/signUp/MemberWriteApplicationTest.java
@@ -1,43 +1,47 @@
 package com.membercontext.memberAPI.application.service.signUp;
 
+import com.membercontext.common.fixture.domain.MemberFixture;
 import com.membercontext.common.stub.JavaCryptoUtilMockStub;
 import com.membercontext.common.stub.MemberJPARepositoryStub;
+import com.membercontext.memberAPI.application.exception.member.MemberErrorCode;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import com.membercontext.memberAPI.application.repository.MemberRepository;
-import com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl.MemberWriteServiceImpl;
-
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl.MemberWriteApplication;
 import com.membercontext.memberAPI.domain.entity.member.Member;
-import com.membercontext.common.fixture.domain.MemberFixture;
+import com.membercontext.memberAPI.domain.entity.member.MemberService;
 import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.NOT_EXITING_USER;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
-class MemberWriteServiceImplTest {
+class MemberWriteApplicationTest {
 
     @InjectMocks
-    private MemberWriteServiceImpl sut;
-
-    @Spy
-    private MemberRepository memberRepository = new MemberJPARepositoryStub();
+    private MemberWriteApplication sut;
 
     @Mock
-    private JavaCryptoUtil encryption = new JavaCryptoUtilMockStub();
+    private MemberService memberService;
 
     @Test
     @DisplayName("회원가입 성공.")
     void signUp() {
         //given
+        String uuid = "uuid";
         Member newMember = MemberFixture.create();
+        when(memberService.signUp(newMember)).thenReturn(uuid);
 
         //when
         String id = sut.signUp(newMember);
@@ -51,9 +55,9 @@ class MemberWriteServiceImplTest {
     void update() {
 
         //given
-        Member originalMember = MemberFixture.create();
-        String id = memberRepository.save(originalMember);
+        String id = "uuid";
         Member updatingMember = MemberFixture.createUpdatingMember(id, "updatedName", "updatedPassword", "updatedname", "010000000", "updatedLoc", false, 10L);
+        when(memberService.update(updatingMember)).thenReturn(updatingMember);
 
         //when
         Member returned = sut.update(updatingMember);
@@ -73,14 +77,14 @@ class MemberWriteServiceImplTest {
     @DisplayName("회원 삭제 성공.")
     void delete() {
         //given
-        Member registeredMember = MemberFixture.create();
-        String id = memberRepository.save(registeredMember);
+        String id = "uuid";
 
         //when
         sut.delete(id);
 
         //then
-        Exception exception = assertThrows(MemberException.class, () -> memberRepository.findById(id));
-        assertEquals(NOT_EXITING_USER.getDeatil(), exception.getMessage());
+        verify(memberService).delete(id);
     }
+
+
 }

--- a/member-context/src/test/java/com/membercontext/memberAPI/domain/entity/member/MemberLocationTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/domain/entity/member/MemberLocationTest.java
@@ -46,7 +46,7 @@ class MemberLocationTest {
             MemberLocation memberLocation = member.getMemberLocation();
 
             //when
-            MemberLocation changedMemberLocation = memberLocation.addLocation(1.0, 2.0, LocalDateTime.of(2021, 1, 1, 0, 0, 0));
+            MemberLocation changedMemberLocation = memberLocation.updateLocation(1.0, 2.0, LocalDateTime.of(2021, 1, 1, 0, 0, 0));
 
             //then
             assertEquals(1.0, changedMemberLocation.getLatitude(member).get());
@@ -72,13 +72,12 @@ class MemberLocationTest {
             MemberLocation memberLocation = member.getMemberLocation();
 
             //when
-            Exception exception = assertThrows(MemberException.class, () -> memberLocation.addLocation(latitude, longitude, timestamp));
+            Exception exception = assertThrows(MemberException.class, () -> memberLocation.updateLocation(latitude, longitude, timestamp));
 
             //then
             assertEquals(exception.getClass(), MemberException.class);
             assertEquals(exception.getMessage(), NO_VALUE.getDeatil());
         }
-
     }
 
     @Nested

--- a/member-context/src/test/java/com/membercontext/memberAPI/domain/entity/member/MemberServiceTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/domain/entity/member/MemberServiceTest.java
@@ -1,0 +1,214 @@
+package com.membercontext.memberAPI.domain.entity.member;
+
+import com.membercontext.common.fixture.web.TrackRequestFixture;
+import com.membercontext.common.stub.JavaCryptoUtilMockStub;
+import com.membercontext.common.stub.MemberJPARepositoryStub;
+import com.membercontext.memberAPI.application.exception.member.MemberErrorCode;
+import com.membercontext.memberAPI.application.exception.member.MemberException;
+import com.membercontext.memberAPI.application.repository.MemberRepository;
+
+import com.membercontext.common.fixture.domain.MemberFixture;
+import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
+import com.membercontext.memberAPI.web.controller.TrackController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.INVALID_PASSWORD;
+import static com.membercontext.memberAPI.application.exception.member.MemberErrorCode.NOT_EXITING_USER;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService sut;
+
+    @Spy
+    private MemberRepository memberRepository = new MemberJPARepositoryStub();
+
+    @Mock
+    private JavaCryptoUtil javaCryptoUtil = new JavaCryptoUtilMockStub();
+
+    @Nested
+    @DisplayName("쓰기 메서드")
+    class write {
+        @Test
+        @DisplayName("회원가입 성공.")
+        void signUp() {
+            //given
+            Member newMember = MemberFixture.create();
+
+            //when
+            String id = sut.signUp(newMember);
+
+            //then
+            assertNotNull(id);
+        }
+
+        @Test
+        @DisplayName("회원 수정 성공.")
+        void update() {
+
+            //given
+            Member originalMember = MemberFixture.create();
+            String id = memberRepository.save(originalMember);
+            Member updatingMember = MemberFixture.createUpdatingMember(id, "updatedName", "updatedPassword", "updatedname", "010000000", "updatedLoc", false, 10L);
+
+            //when
+            Member returned = sut.update(updatingMember);
+
+            //then
+            assertEquals(updatingMember.getId(), returned.getId());
+            assertEquals(updatingMember.getEmail(), returned.getEmail());
+            assertEquals(updatingMember.getName(), returned.getName());
+            assertEquals(updatingMember.getPassword(), returned.getPassword());
+            assertEquals(updatingMember.getPhone(), returned.getPhone());
+            assertEquals(updatingMember.getAddress(), returned.getAddress());
+            assertEquals(updatingMember.isLocationServiceEnabled(), returned.isLocationServiceEnabled());
+            assertEquals(updatingMember.getPoint(), returned.getPoint());
+        }
+
+        @Test
+        @DisplayName("회원 삭제 성공.")
+        void delete() {
+            //given
+            Member registeredMember = MemberFixture.create();
+            String id = memberRepository.save(registeredMember);
+
+            //when
+            sut.delete(id);
+
+            //then
+            Exception exception = assertThrows(MemberException.class, () -> memberRepository.findById(id));
+            assertEquals(NOT_EXITING_USER.getDeatil(), exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("조회 메서드")
+    class read {
+        @Test
+        @DisplayName("아이디로 회원 정보 가져옴")
+        void getMemberInfo() {
+            //given
+            Member memberToSearch = MemberFixture.create();
+            String id = memberRepository.save(memberToSearch);
+
+            //when
+            Member memberReturned = sut.findOneMember(id);
+
+            //then
+            assertEquals(id, memberReturned.getId());
+            assertEquals(memberToSearch.getPassword(), memberReturned.getPassword());
+            assertEquals(memberToSearch.getEmail(), memberReturned.getEmail());
+            assertEquals(memberToSearch.getName(), memberReturned.getName());
+            assertEquals(memberToSearch.getPhone(), memberReturned.getPhone());
+            assertEquals(memberToSearch.getAddress(), memberReturned.getAddress());
+            assertEquals(memberToSearch.isLocationServiceEnabled(), memberReturned.isLocationServiceEnabled());
+            assertEquals(memberToSearch.getPoint(), memberReturned.getPoint());
+        }
+
+        @Test
+        @DisplayName("아이디로 회원 정보 가져옴 - 회원이 없는 경우")
+        void getMemberInfo_NotExistingUser() {
+            //given
+            String id = "notExistingId";
+
+            //when
+            Exception exception = assertThrows(Exception.class, () -> sut.findOneMember(id));
+
+            //then
+            assertEquals(exception.getClass(), MemberException.class);
+            assertEquals(exception.getMessage(), MemberErrorCode.NOT_EXITING_USER.getDeatil());
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 메서드")
+    class logIn {
+        @Test
+        @DisplayName("로그인 성공")
+        void logIn() {
+            //given
+            Member member = MemberFixture.create();
+            String id = memberRepository.save(member);
+            when(javaCryptoUtil.encrypt(member.getPassword())).thenReturn(member.getPassword());
+
+            //when
+            Member logInMember = sut.logIn(member.getEmail(), member.getPassword());
+
+            //then
+            assertEquals(id, logInMember.getId());
+            assertEquals(member.getEmail(), logInMember.getEmail());
+            assertEquals(member.getName(), logInMember.getName());
+            assertEquals(member.getPhone(), logInMember.getPhone());
+            assertEquals(member.getAddress(), logInMember.getAddress());
+            assertEquals(member.getPoint(), logInMember.getPoint());
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 비밀번호 불일치")
+        void logIn_PasswordInvalid() {
+            //given
+            Member member = MemberFixture.create();
+            String id = memberRepository.save(member);
+            when(javaCryptoUtil.encrypt(member.getPassword())).thenReturn(null);
+
+            //when
+            Exception exception = assertThrows(MemberException.class, () -> sut.logIn(member.getEmail(), member.getPassword()));
+
+            //then
+            assertEquals(exception.getClass(), MemberException.class);
+            assertEquals(exception.getMessage(), INVALID_PASSWORD.getDeatil());
+        }
+    }
+
+    @Nested
+    @DisplayName("위치 추적 메서드")
+    class track {
+        @Test
+        @DisplayName("현재 위치 저장")
+        void startLocationTracking() {
+            // given
+            Member member = MemberFixture.create();
+            String id = memberRepository.save(member);
+            TrackController.TrackRequest request = TrackRequestFixture.create();
+
+            //when
+            sut.startLocationTracking(id, request);
+
+            // then
+            Member updatedMember = memberRepository.findById(id);
+            assertEquals(updatedMember.getMemberLocation().getLongitude(updatedMember).get(), request.getLongitude());
+            assertEquals(updatedMember.getMemberLocation().getLatitude(updatedMember).get(), request.getLatitude());
+            assertEquals(updatedMember.getMemberLocation().getTimestamp(updatedMember).get(), request.getTimestamp());
+        }
+
+        @Test
+        @DisplayName("FCM 토큰 저장")
+        void enablePushAlarm() {
+            // given
+            String token = "token";
+            Member member = MemberFixture.create();
+            String id = memberRepository.save(member);
+
+            //when
+            sut.enablePushAlarm(token, id);
+
+            // then
+            Member updatedMember = memberRepository.findById(id);
+            assertThat(updatedMember.getMemberLocation().getFcmToken()).isEqualTo(token);
+        }
+
+    }
+
+}

--- a/member-context/src/test/java/com/membercontext/memberAPI/domain/entity/member/MemberTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/domain/entity/member/MemberTest.java
@@ -22,23 +22,6 @@ import static org.mockito.Mockito.*;
 class MemberTest {
 
     @Test
-    @DisplayName("회원가입 성공")
-    void signUp() {
-        //given
-        Member member = MemberFixture.createMemberWithId("UUID");
-
-        String password = "encryptedPassword";
-        JavaCryptoUtil javaCryptoUtil = mock(JavaCryptoUtil.class);
-        when(javaCryptoUtil.encrypt(member.getPassword())).thenReturn(password);
-
-        //when
-        member.signUp(javaCryptoUtil);
-
-        //then
-        assertEquals(password, member.getPassword());
-    }
-
-    @Test
     void logIn() {
         //given
         Member member = MemberFixture.createMemberWithId("UUID");

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/dto/request/signUp/SignUpRequestTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/dto/request/signUp/SignUpRequestTest.java
@@ -2,7 +2,7 @@ package com.membercontext.memberAPI.web.controller.dto.request.signUp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.membercontext.common.fixture.web.crud.SignUpRequestFixture;
-import com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl.MemberWriteServiceImpl;
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl.MemberWriteApplication;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.memberAPI.web.controller.SignUpController;
 
@@ -32,7 +32,7 @@ class SignUpRequestTest {
     private ObjectMapper mapper;
 
     @MockBean
-    private MemberWriteServiceImpl signUpService;
+    private MemberWriteApplication signUpService;
 
     private final String requestURL = "/sign-in";
 

--- a/member-context/src/test/java/com/membercontext/memberAPI/web/controller/dto/request/signUp/UpdateRequestTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/web/controller/dto/request/signUp/UpdateRequestTest.java
@@ -1,7 +1,7 @@
 package com.membercontext.memberAPI.web.controller.dto.request.signUp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl.MemberWriteServiceImpl;
+import com.membercontext.memberAPI.application.service.MemberWriteSerivces.Impl.MemberWriteApplication;
 import com.membercontext.memberAPI.domain.entity.member.Member;
 import com.membercontext.memberAPI.web.controller.SignUpController;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +28,7 @@ class UpdateRequestTest {
     @Autowired
     private ObjectMapper mapper;
     @MockBean
-    private MemberWriteServiceImpl signUpService;
+    private MemberWriteApplication signUpService;
 
     private final String requestURL = "/sign-in";
     private SignUpController.UpdateRequest req;


### PR DESCRIPTION
### 변경사항

- MemberService 제작
- Q. 도메인 서비스에서 사용되는 도메인의 메서드는 protected로 사용하려고 하는데 제가 놓치는 사항이 없을까요?
  - 이슈: 도메인 서비스에서 변경되는 사항들을 조금 더 캡슐화 하기 위해서 도메인 서비스를 같은 패키지에 두고 도메인 서비스에 쓰일 도메인의 메서드들을 protected로 사용하려고 합니다. (예를 들면 encryptPassword 같은 메서드들 입니다 -> [링크](https://github.com/f-lab-edu/check-in-before-leaving/blob/0b6af65be14170adb5df0e2cb9199fe817297eaa/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/Member.java))
  - 장점: 장점은 아무래도 캡슐화로서의 장점인 다른 영역에서 이 메서드를 사용되기 어려워서 변경의 범위를 제한할 수 있습니다.
  - 단점: 단점은 도메인이나 도메인 서비스 파일의 위치 변경시 갑자기 작동되지 않을수 있습니다. 그래서 MemberService의 위에 주석을 달아 놓았습니다.
  - 결론: 저는 변경에 취약할 수 있는 주석의 사용이 조금 걸리지만, 주석을 통해 다른 개발자들에게 의도를 알릴 수 있고 캡슐화를 통해 변경에 대한 안정성이 생기는 장점이 주석으로 잃는 단점보다 크다고 생각합니다. 혹시 제가 챙기지 못한 부분이 있을까 해서 질문 드립니다.