### PR TITLE
[Hotfix-07-3-도메인서비스-적용]

### DIFF
--- a/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/Member.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/Member.java
@@ -65,7 +65,7 @@ public class Member {
     }
 
     // Update
-    public Member update(Member updatingMember) { //public
+    protected Member update(Member updatingMember) { //public
         this.email = updatingMember.getEmail();
         this.password = updatingMember.getPassword();
         this.name = updatingMember.getName();

--- a/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepository.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepository.java
@@ -3,6 +3,7 @@ package com.membercontext.memberAPI.infrastructure.db.jpa.member;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.domain.entity.member.Member;
+import com.membercontext.memberAPI.domain.entity.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -46,7 +47,8 @@ public class MemberJPARepository implements MemberRepository {
     @Override
     public Member update(Member updatingMember) {
         Member member = this.findById(updatingMember.getId());
-        member.update(updatingMember);
+        MemberService memberService = new MemberService(this, null);
+        memberService.update(updatingMember);
         return member;
     }
 

--- a/member-context/src/test/java/com/membercontext/common/stub/MemberJPARepositoryStub.java
+++ b/member-context/src/test/java/com/membercontext/common/stub/MemberJPARepositoryStub.java
@@ -4,6 +4,7 @@ import com.membercontext.common.fixture.domain.MemberFixture;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
 import com.membercontext.memberAPI.application.repository.MemberRepository;
 import com.membercontext.memberAPI.domain.entity.member.Member;
+import com.membercontext.memberAPI.domain.entity.member.MemberService;
 
 import java.util.*;
 
@@ -56,7 +57,8 @@ public class MemberJPARepositoryStub implements MemberRepository {
     @Override
     public Member update(Member updatingMember) {
         Member member = findById(updatingMember.getId());
-        member.update(updatingMember);
+        MemberService memberService = new MemberService(this, null);
+        memberService.update(updatingMember);
         return member;
     }
 


### PR DESCRIPTION
### 변경사항

- Member 엔티티의 update도 protected로 변경하였습니다. 
- MemberJPARepository에서 사용해서 public으로 두려다가 도메인 서비스에서 사용되는 엔티티의 코드를 protected를 사용하도록 결정하려면 코드에서 일관성 있게 사용해야 된다고 생각해서, MemberService를 부분적으로 주입받아 상태변경을 하도록 하였습니다.