### PR TITLE
[Hotfix-12-1-도메인-엔티티-책임-분할] 도메인서비스 repository에 수동 주입하던 부분 해결.

### DIFF
--- a/member-context/build.gradle
+++ b/member-context/build.gradle
@@ -99,6 +99,11 @@ dependencies {
     testAnnotationProcessor('org.projectlombok:lombok')
     testImplementation 'org.springframework.kafka:spring-kafka-test'
 
+    //testcontainers
+    testImplementation 'org.testcontainers:testcontainers:1.19.3'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
+    testImplementation 'org.testcontainers:mysql'
+
 }
 
 tasks.named('test') {

--- a/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/MemberService.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/domain/entity/member/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
 
     public Member update(Member updatingMember) {
         Member member = memberRepository.findById(updatingMember.getId());
-        return member.update(updatingMember);
+        return memberRepository.update(updatingMember);
     }
 
     public void delete(String id) {

--- a/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepository.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/db/jpa/member/MemberJPARepository.java
@@ -46,10 +46,10 @@ public class MemberJPARepository implements MemberRepository {
 
     @Override
     public Member update(Member updatingMember) {
-        Member member = this.findById(updatingMember.getId());
-        MemberService memberService = new MemberService(this, null);
-        memberService.update(updatingMember);
-        return member;
+        memberSpringJPARepository.save(updatingMember);
+
+        return memberSpringJPARepository.findById(updatingMember.getId())
+                .orElseThrow(() -> new MemberException(NOT_EXITING_USER));
     }
 
     @Override

--- a/member-context/src/test/java/com/membercontext/common/stub/MemberSpringJPARepositoryStub.java
+++ b/member-context/src/test/java/com/membercontext/common/stub/MemberSpringJPARepositoryStub.java
@@ -1,7 +1,6 @@
 package com.membercontext.common.stub;
 
 import com.membercontext.common.exception.NoStubException;
-import com.membercontext.common.exception.TestException;
 import com.membercontext.common.fixture.domain.MemberFixture;
 import com.membercontext.memberAPI.application.exception.member.MemberErrorCode;
 import com.membercontext.memberAPI.application.exception.member.MemberException;
@@ -16,8 +15,6 @@ import org.springframework.data.repository.query.FluentQuery;
 import java.util.*;
 import java.util.function.Function;
 
-import static com.membercontext.common.exception.TestException.NOT_ALLOWED;
-
 public class MemberSpringJPARepositoryStub implements MemberSpringJPARepository {
 
     Set<Member> members = new HashSet<>();
@@ -26,11 +23,14 @@ public class MemberSpringJPARepositoryStub implements MemberSpringJPARepository 
     public <S extends Member> S save(S entity) {
         if (members.stream().anyMatch(member -> member.getEmail().equals(entity.getEmail()))) {
             throw new MemberException(MemberErrorCode.ALREADY_REGISTERED_USER);
+        } else if (members.stream().anyMatch(member -> member.getId().equals(entity.getId()))) {
+            throw new MemberException(MemberErrorCode.ALREADY_REGISTERED_USER);
         }
         UUID uuid = UUID.randomUUID();
         Member member = MemberFixture.createMemberToSave(uuid.toString(), entity);
         members.add(member);
-        return (S) member;
+
+        return (S) members.stream().filter(member1 -> member1.getId().equals(member.getId())).findFirst().get();
     }
 
     @Override

--- a/member-context/src/test/java/com/membercontext/common/stub/test/MemberJPARepositoryStubIntegratedTest.java
+++ b/member-context/src/test/java/com/membercontext/common/stub/test/MemberJPARepositoryStubIntegratedTest.java
@@ -11,13 +11,22 @@ import com.membercontext.memberAPI.domain.entity.member.MemberService;
 import com.membercontext.memberAPI.infrastructure.db.jpa.member.MemberJPARepository;
 import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
 import com.membercontext.memberAPI.web.controller.TrackController;
+import net.bytebuddy.utility.dispatcher.JavaDispatcher;
+import org.junit.ClassRule;
 import org.junit.jupiter.api.*;
 
 import org.mockito.Spy;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.List;
 
@@ -31,9 +40,30 @@ import static org.mockito.Mockito.mock;
 
 
 @SpringBootTest
+@Testcontainers
 @Transactional
-@Disabled
 class MemberJPARepositoryStubIntegratedTest {
+
+    private static final String USERNAME = "root";
+    private static final String PASSWORD = "password";
+    private static final String DATABASE_NAME = "mysql_testcontainer";
+
+    @ClassRule
+    @Container
+    public static MySQLContainer<?> mySQLContainer = new MySQLContainer<>("mysql:8.0")
+            .withUsername(USERNAME)
+            .withPassword(PASSWORD)
+            .withDatabaseName(DATABASE_NAME);
+
+    @DynamicPropertySource
+    public static void overrideProps(DynamicPropertyRegistry dynamicPropertyRegistry) {
+
+        dynamicPropertyRegistry.add("spring.datasource.url", () -> mySQLContainer.getJdbcUrl());
+        dynamicPropertyRegistry.add("spring.datasource.username", () -> USERNAME);
+        dynamicPropertyRegistry.add("spring.datasource.password", () -> PASSWORD);
+        dynamicPropertyRegistry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+
+    }
 
     @Spy
     private MemberJPARepositoryStub stub;
@@ -197,6 +227,7 @@ class MemberJPARepositoryStubIntegratedTest {
     @Nested
     @DisplayName("update 테스트")
     @SpringBootTest
+    @Disabled
     class updateTest {
 
         @Test

--- a/member-context/src/test/java/com/membercontext/common/stub/test/MemberSpringJPARespotiroyStubIntegratedTest.java
+++ b/member-context/src/test/java/com/membercontext/common/stub/test/MemberSpringJPARespotiroyStubIntegratedTest.java
@@ -14,13 +14,22 @@ import com.membercontext.memberAPI.infrastructure.db.jpa.member.MemberJPAReposit
 import com.membercontext.memberAPI.infrastructure.db.jpa.member.MemberSpringJPARepository;
 import com.membercontext.memberAPI.infrastructure.encryption.JavaCryptoUtil;
 import com.membercontext.memberAPI.web.controller.TrackController;
-import org.junit.jupiter.api.*;
+import org.junit.ClassRule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
 
@@ -32,8 +41,29 @@ import static org.mockito.Mockito.mock;
 
 @SpringBootTest
 @Transactional
-@Disabled
+@Testcontainers
 public class MemberSpringJPARespotiroyStubIntegratedTest {
+
+    private static final String USERNAME = "root";
+    private static final String PASSWORD = "password";
+    private static final String DATABASE_NAME = "mysql_testcontainer";
+
+    @ClassRule
+    @Container
+    public static MySQLContainer<?> mySQLContainer = new MySQLContainer<>("mysql:8.0")
+            .withUsername(USERNAME)
+            .withPassword(PASSWORD)
+            .withDatabaseName(DATABASE_NAME);
+
+    @DynamicPropertySource
+    public static void overrideProps(DynamicPropertyRegistry dynamicPropertyRegistry) {
+
+        dynamicPropertyRegistry.add("spring.datasource.url", () -> mySQLContainer.getJdbcUrl());
+        dynamicPropertyRegistry.add("spring.datasource.username", () -> USERNAME);
+        dynamicPropertyRegistry.add("spring.datasource.password", () -> PASSWORD);
+        dynamicPropertyRegistry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+    }
+
 
     @Autowired
     private MemberSpringJPARepository memberSpringJPARepository;


### PR DESCRIPTION
### 변경사항

- 일단 멘토링때 1차로 해결했던 대로 더티체킹으로 업데이트 하는 방법이 아닌 리포지토리에서 바로 세이브하는 방식으로 변경 해결하였습니다.
- protected를 public으로 바꾸고 DTO를 내어주는 방법으로도 이후 변경해 보려고 합니다.