### PR TITLE
[54-little-sns-도메인-1차]

### DIFF
--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/MemberInfo.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/MemberInfo.java
@@ -1,0 +1,20 @@
+package com.littleSNSMS.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+public final class MemberInfo {
+    private final String memberId;
+    private final String MemberEmail;
+
+    public MemberInfo(String memberId, String MemberEmail) {
+        this.memberId = memberId;
+        this.MemberEmail = MemberEmail;
+    }
+}

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/Post.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/Post.java
@@ -1,0 +1,52 @@
+package com.littleSNSMS.domain;
+
+import com.littleSNSMS.domain.dto.PostDTO;
+import com.littleSNSMS.domain.exception.PostException;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Setter(AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
+public final class Post {
+
+    @Getter
+    private final String contents;
+
+    @Getter
+    private final MemberInfo owner;
+
+    @Getter
+    private final List<MemberInfo> likes = List.of();
+
+    private final Long postId;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+
+    public static Post post(PostDTO.Create dto) {
+        return Post.builder()
+                .contents(dto.getContent())
+                .owner(new MemberInfo(dto.getOwner().getMemberId(), dto.getOwner().getMemberName()))
+                .build();
+    }
+
+    public Long getPostId() {
+        if (postId == null) throw new PostException(PostException.POST_NOT_YET_EXIST);
+        return postId;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        if (createdAt == null) throw new PostException(PostException.POST_NOT_YET_EXIST);
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        if (updatedAt == null) throw new PostException(PostException.POST_NOT_YET_EXIST);
+        return updatedAt;
+    }
+
+}

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/dto/PostDTO.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/dto/PostDTO.java
@@ -1,0 +1,51 @@
+package com.littleSNSMS.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+public class PostDTO {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
+    @RequiredArgsConstructor
+    public static final class MemberInfoDTO {
+        private final String memberId;
+        private final String memberName;
+    }
+
+    @Getter
+    @NoArgsConstructor(force = true)
+    @RequiredArgsConstructor
+    public static final class Create {
+        private final String content;
+        private final MemberInfoDTO owner;
+
+        public static Create of(String content, String memberId, String memberName) {
+            return new Create(content, new MemberInfoDTO(memberId, memberName));
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(force = true)
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Update {
+        //todo: 이후 이 부분도 로직 개발
+        private final long id;
+        private final String content;
+        private final MemberInfoDTO owner;
+
+        public static Update of(Long id, String content, String memberId, String memberName) {
+            return new Update(id, content, new MemberInfoDTO(memberId, memberName));
+        }
+    }
+
+    public static class Return {
+        //todo: 이후 이 로직 추가 개발
+        private Long id;
+        private String content;
+        private Long memberId;
+        private String memberName;
+    }
+
+}

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/exception/PostException.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/exception/PostException.java
@@ -1,0 +1,10 @@
+package com.littleSNSMS.domain.exception;
+
+public class PostException extends RuntimeException {
+    public static String POST_NOT_YET_EXIST = "아직 포스트 되지 않았습니다.";
+
+    public PostException(String message) {
+        super(message);
+    }
+
+}

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/service/PostService.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/service/PostService.java
@@ -1,0 +1,18 @@
+package com.littleSNSMS.domain.service;
+
+import com.littleSNSMS.domain.Post;
+import com.littleSNSMS.domain.PostRepository;
+import com.littleSNSMS.domain.dto.PostDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    public Long post(PostDTO.Create dto) {
+        return postRepository.save(Post.post(dto));
+    }
+}

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/domain/MemberInfoTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/domain/MemberInfoTest.java
@@ -1,0 +1,20 @@
+package com.littleSNSMS.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemberInfoTest {
+
+    @Test
+    void memberInfo() {
+        String memberId = "testUUID";
+        String memberName = "testName";
+
+        MemberInfo memberInfo = new MemberInfo(memberId, memberName);
+
+        assertEquals(memberId, memberInfo.getMemberId());
+        assertEquals(memberName, memberInfo.getMemberEmail());
+    }
+
+}

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/domain/PostTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/domain/PostTest.java
@@ -1,0 +1,96 @@
+package com.littleSNSMS.domain;
+
+import com.littleSNSMS.domain.dto.PostDTO;
+import com.littleSNSMS.domain.exception.PostException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostTest {
+
+    @Test
+    @DisplayName("Post 생성")
+    void post() {
+        //given
+        String contents = "testContent";
+        String memberId = "testUUID";
+        String memberName = "testName";
+
+        PostDTO.Create create = PostDTO.Create.of(contents, memberId, memberName);
+
+        //when
+        Post post = Post.post(create);
+
+        //then
+        assertEquals(contents, post.getContents());
+        assertEquals(memberId, post.getOwner().getMemberId());
+        assertEquals(memberName, post.getOwner().getMemberEmail());
+    }
+
+    @Nested
+    @DisplayName("Getters")
+    class getters {
+        @Test
+        @DisplayName("Post ID 반환 실패")
+        void getPostId() {
+            //given
+            String contents = "testContent";
+            String memberId = "testUUID";
+            String memberName = "testName";
+            Post post = Post.post(PostDTO.Create.of("testContent", "testUUID", "testName"));
+
+            //when
+            Exception ex = assertThrows(PostException.class, () -> post.getPostId());
+
+            //then
+            assertEquals(PostException.POST_NOT_YET_EXIST, ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("생성일 반환 실패")
+        void getCreatedAt() {
+            //given
+            String contents = "testContent";
+            String memberId = "testUUID";
+            String memberName = "testName";
+            Post post = Post.post(PostDTO.Create.of("testContent", "testUUID", "testName"));
+
+            //when
+            Exception ex = assertThrows(PostException.class, () -> post.getCreatedAt());
+
+            //then
+            assertEquals(PostException.POST_NOT_YET_EXIST, ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("수정일 반환 실패")
+        void getUpdatedAt() {
+            //given
+            String contents = "testContent";
+            String memberId = "testUUID";
+            String memberName = "testName";
+            Post post = Post.post(PostDTO.Create.of("testContent", "testUUID", "testName"));
+
+            //when
+            Exception ex = assertThrows(PostException.class, () -> post.getUpdatedAt());
+
+            //then
+            assertEquals(PostException.POST_NOT_YET_EXIST, ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("좋아요 0개")
+        void getLikes() {
+            //given
+            String contents = "testContent";
+            String memberId = "testUUID";
+            String memberName = "testName";
+            Post post = Post.post(PostDTO.Create.of("testContent", "testUUID", "testName"));
+
+            //then
+            assertEquals(0, post.getLikes().size());
+        }
+    }
+}

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/domain/dto/PostDTOTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/domain/dto/PostDTOTest.java
@@ -1,0 +1,48 @@
+package com.littleSNSMS.domain.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class PostDTOTest {
+
+    @Test
+    void memberInfoDTO() {
+        String memberId = "testUUID";
+        String memberEmail = "testName";
+
+        PostDTO.MemberInfoDTO memberInfoDTO = new PostDTO.MemberInfoDTO(memberId, memberEmail);
+
+        assertEquals(memberId, memberInfoDTO.getMemberId());
+        assertEquals(memberEmail, memberInfoDTO.getMemberName());
+    }
+
+    @Test
+    void create() {
+        String content = "testContent";
+        String memberId = "testUUID";
+        String memberName = "testName";
+
+        PostDTO.Create create = PostDTO.Create.of(content, memberId, memberName);
+
+        assertEquals(content, create.getContent());
+        assertEquals(memberId, create.getOwner().getMemberId());
+        assertEquals(memberName, create.getOwner().getMemberName());
+    }
+
+    @Test
+    void update() {
+        Long id = 1L;
+        String content = "testContent";
+        String memberId = "testUUID";
+        String memberName = "testName";
+
+        PostDTO.Update update = PostDTO.Update.of(id, content, memberId, memberName);
+
+        assertEquals(id, update.getId());
+        assertEquals(content, update.getContent());
+        assertEquals(memberId, update.getOwner().getMemberId());
+        assertEquals(memberName, update.getOwner().getMemberName());
+    }
+}

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/domain/service/PostServiceTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/domain/service/PostServiceTest.java
@@ -1,0 +1,30 @@
+package com.littleSNSMS.domain.service;
+
+import com.littleSNSMS.domain.Post;
+import com.littleSNSMS.domain.PostRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+    
+    private PostRepository postRepository = spy(PostRepository.class);
+
+    @Test
+    void post() {
+        //given
+        Post post = mock(Post.class);
+
+        //when
+        Long id = postRepository.save(post);
+
+        //then
+        assertNotNull(id);
+        verify(postRepository).save(post);
+    }
+}


### PR DESCRIPTION
### 변경사항

- 이번에는 Request를 바로 도메인에 쓰는게 아니라 DTO로 받아서 쓰려고 합니다.
  - DTO들을 이렇게 하나의 클래스에 모아서 쓰는게 어떨까 생각해 보았습니다.

- r2dbc의 엔티티 작성법이 도메인 모델과 다른면이 있어 이번에도 인프라의 엔티티와 도메인의 엔티티를 나누어서 작성하려고 합니다. 

- 모델링 변경

[이전 모델링]
![엔티티3 drawio](https://github.com/user-attachments/assets/721a3947-6296-4851-84db-62a5866c95e4)

[현재 모델링]
![엔티티2 drawio](https://github.com/user-attachments/assets/fb7a7dc4-d53d-4675-8aef-12ffda194e69)

 
  - "Like"가 아닌 "MemberInfo"라는 "맴버정보"를 담은 값객체로 변경하였습니다.
    - 테크스펙에 있던 "Like"는 좋아요를 누른 맴버들을 간단한 정보(MemberInfo)들을 리스트로 모아서 "Post"에게 전달해 주는게 역할을 하고 있었습니다.
    - 생각해보니 결국 테이블은 "MemberInfo"라는 정보를 담고 있고 "Like"에 관련된 컬럼은 없으며, "Like" 객체는 단순히 이걸 리스트로 만들어서 "Post"에게 전달하는 추가 동작을 하는 값객체였습니다.
    - 이 동작을 캡슐화하여 "Like"에서 해주었을때의 효과보다 "Post"가 유연하게 "MemberInfo"를 사용하는 장점이 크다고 생각해 "Like"가 아닌 "MemberInfo"와 상호작용 하는것으로 변경하였습니다.