### PR TITLE
[55-little-sns-도메인-2차] null 관리 코드 추가

### DIFF
--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/MemberInfo.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/MemberInfo.java
@@ -1,5 +1,6 @@
 package com.littleSNSMS.domain;
 
+import com.littleSNSMS.domain.exception.PostException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,12 +9,15 @@ import lombok.Setter;
 
 @Getter
 @Setter(AccessLevel.PRIVATE)
-@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public final class MemberInfo {
     private final String memberId;
     private final String MemberEmail;
 
     public MemberInfo(String memberId, String MemberEmail) {
+        if (memberId == null) throw new PostException(PostException.NO_MEMBER_ID_VALUE);
+        if (MemberEmail == null) throw new PostException(PostException.NO_MEMBER_EMAIL_VALUE);
+
         this.memberId = memberId;
         this.MemberEmail = MemberEmail;
     }

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/Post.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/Post.java
@@ -7,9 +7,6 @@ import lombok.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Setter(AccessLevel.PRIVATE)
-@Builder(access = AccessLevel.PRIVATE)
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public final class Post {
 
@@ -20,18 +17,44 @@ public final class Post {
     private final MemberInfo owner;
 
     @Getter
-    private final List<MemberInfo> likes = List.of();
+    private List<MemberInfo> likes = List.of();
 
     private final Long postId;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
+    private Post(String contents, MemberInfo owner, List<MemberInfo> likes, boolean isCreating) {
+        if (isCreating) {
+            this.contents = contents;
+            this.owner = owner;
+            this.likes = likes;
+            this.createdAt = null;
+            this.updatedAt = null;
+            this.postId = null;
+        } else {
+            throw new PostException(PostException.NOT_POSTING_REQUEST);
+        }
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Post(String contents, MemberInfo owner, Long postId, LocalDateTime createdAt, LocalDateTime updatedAt, List<MemberInfo> likes) {
+        if (contents == null) throw new PostException(PostException.NO_CONTENT_VALUE);
+        if (owner == null) throw new PostException(PostException.NO_OWNER_VALUE);
+        if (postId == null) throw new PostException(PostException.NO_POST_ID_VALUE);
+        if (createdAt == null) throw new PostException(PostException.NO_CREATED_AT_VALUE);
+        if (updatedAt == null) throw new PostException(PostException.NO_UPDATED_AT_VALUE);
+        if (likes == null) throw new PostException(PostException.NO_LIKES_VALUE);
+
+        this.contents = contents;
+        this.owner = owner;
+        this.postId = postId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.likes = likes;
+    }
 
     public static Post post(PostDTO.Create dto) {
-        return Post.builder()
-                .contents(dto.getContent())
-                .owner(new MemberInfo(dto.getOwner().getMemberId(), dto.getOwner().getMemberName()))
-                .build();
+        return new Post(dto.getContent(), new MemberInfo(dto.getOwner().getMemberId(), dto.getOwner().getMemberEmail()), List.of(), true);
     }
 
     public Long getPostId() {

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/dto/PostDTO.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/dto/PostDTO.java
@@ -1,6 +1,5 @@
 package com.littleSNSMS.domain.dto;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -11,7 +10,8 @@ public class PostDTO {
     @RequiredArgsConstructor
     public static final class MemberInfoDTO {
         private final String memberId;
-        private final String memberName;
+        private final String memberEmail;
+
     }
 
     @Getter
@@ -19,33 +19,11 @@ public class PostDTO {
     @RequiredArgsConstructor
     public static final class Create {
         private final String content;
-        private final MemberInfoDTO owner;
+        private final MemberInfoDTO owner; //todo: 사실상 Like
 
-        public static Create of(String content, String memberId, String memberName) {
-            return new Create(content, new MemberInfoDTO(memberId, memberName));
+        public static Create of(String content, String memberId, String memberEmail) {
+            return new Create(content, new MemberInfoDTO(memberId, memberEmail));
         }
-    }
-
-    @Getter
-    @NoArgsConstructor(force = true)
-    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class Update {
-        //todo: 이후 이 부분도 로직 개발
-        private final long id;
-        private final String content;
-        private final MemberInfoDTO owner;
-
-        public static Update of(Long id, String content, String memberId, String memberName) {
-            return new Update(id, content, new MemberInfoDTO(memberId, memberName));
-        }
-    }
-
-    public static class Return {
-        //todo: 이후 이 로직 추가 개발
-        private Long id;
-        private String content;
-        private Long memberId;
-        private String memberName;
     }
 
 }

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/exception/PostException.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/exception/PostException.java
@@ -2,6 +2,18 @@ package com.littleSNSMS.domain.exception;
 
 public class PostException extends RuntimeException {
     public static String POST_NOT_YET_EXIST = "아직 포스트 되지 않았습니다.";
+    public static String NOT_POSTING_REQUEST = "포스트 등록 요청이 아닙니다.";
+
+    public static String NO_CONTENT_VALUE = "포스트 내용이 없습니다.";
+    public static String NO_OWNER_VALUE = "포스트 소유자가 없습니다.";
+    public static String NO_POST_ID_VALUE = "포스트 아이디가 없습니다.";
+    public static String NO_CREATED_AT_VALUE = "포스트 생성일이 없습니다.";
+    public static String NO_UPDATED_AT_VALUE = "포스트 수정일이 없습니다.";
+    public static String NO_LIKES_VALUE = "포스트 좋아요 리스트가 없습니다.";
+
+    public static String NO_MEMBER_ID_VALUE = "멤버 아이디가 없습니다.";
+    public static String NO_MEMBER_EMAIL_VALUE = "멤버 이메일이 없습니다.";
+
 
     public PostException(String message) {
         super(message);

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/domain/PostTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/domain/PostTest.java
@@ -6,27 +6,61 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class PostTest {
 
-    @Test
+    @Nested
     @DisplayName("Post 생성")
-    void post() {
-        //given
-        String contents = "testContent";
-        String memberId = "testUUID";
-        String memberName = "testName";
+    class post {
+        @Test
+        @DisplayName("Post 생성 성공")
+        void postSuccessful() {
+            //given
+            String contents = "testContent";
+            String memberId = "testUUID";
+            String memberName = "testName";
 
-        PostDTO.Create create = PostDTO.Create.of(contents, memberId, memberName);
+            PostDTO.Create create = PostDTO.Create.of(contents, memberId, memberName);
 
-        //when
-        Post post = Post.post(create);
+            //when
+            Post post = Post.post(create);
 
-        //then
-        assertEquals(contents, post.getContents());
-        assertEquals(memberId, post.getOwner().getMemberId());
-        assertEquals(memberName, post.getOwner().getMemberEmail());
+            //then
+            assertEquals(contents, post.getContents());
+            assertEquals(memberId, post.getOwner().getMemberId());
+            assertEquals(memberName, post.getOwner().getMemberEmail());
+        }
+
+        @Test
+        @DisplayName("Post 생성 아닌 경우")
+        void postNotTheCase() {
+            try {
+                //given
+                Class<Post> clazz = Post.class;
+                Constructor<Post> constructorForPosting = clazz.getDeclaredConstructor(String.class, MemberInfo.class, List.class, boolean.class);
+                constructorForPosting.setAccessible(true);
+
+                //when
+                Post post = constructorForPosting.newInstance("testContent", new MemberInfo("testUUID", "testName"), List.of(), true);
+                Exception ex = assertThrows(InvocationTargetException.class, () -> {
+                    constructorForPosting.newInstance("testContent", new MemberInfo("testUUID", "testName"), List.of(), false);
+                });
+
+                //then;
+                assertTrue(ex.getCause() instanceof PostException);
+                Exception result = (PostException) ex.getCause();
+                assertEquals(PostException.NOT_POSTING_REQUEST, result.getMessage());
+
+            } catch (NoSuchMethodException | IllegalAccessException | InstantiationException |
+                     InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     @Nested
@@ -36,13 +70,10 @@ class PostTest {
         @DisplayName("Post ID 반환 실패")
         void getPostId() {
             //given
-            String contents = "testContent";
-            String memberId = "testUUID";
-            String memberName = "testName";
             Post post = Post.post(PostDTO.Create.of("testContent", "testUUID", "testName"));
 
             //when
-            Exception ex = assertThrows(PostException.class, () -> post.getPostId());
+            Exception ex = assertThrows(PostException.class, post::getPostId);
 
             //then
             assertEquals(PostException.POST_NOT_YET_EXIST, ex.getMessage());
@@ -52,13 +83,10 @@ class PostTest {
         @DisplayName("생성일 반환 실패")
         void getCreatedAt() {
             //given
-            String contents = "testContent";
-            String memberId = "testUUID";
-            String memberName = "testName";
             Post post = Post.post(PostDTO.Create.of("testContent", "testUUID", "testName"));
 
             //when
-            Exception ex = assertThrows(PostException.class, () -> post.getCreatedAt());
+            Exception ex = assertThrows(PostException.class, post::getCreatedAt);
 
             //then
             assertEquals(PostException.POST_NOT_YET_EXIST, ex.getMessage());
@@ -68,13 +96,10 @@ class PostTest {
         @DisplayName("수정일 반환 실패")
         void getUpdatedAt() {
             //given
-            String contents = "testContent";
-            String memberId = "testUUID";
-            String memberName = "testName";
             Post post = Post.post(PostDTO.Create.of("testContent", "testUUID", "testName"));
 
             //when
-            Exception ex = assertThrows(PostException.class, () -> post.getUpdatedAt());
+            Exception ex = assertThrows(PostException.class, post::getUpdatedAt);
 
             //then
             assertEquals(PostException.POST_NOT_YET_EXIST, ex.getMessage());
@@ -84,9 +109,6 @@ class PostTest {
         @DisplayName("좋아요 0개")
         void getLikes() {
             //given
-            String contents = "testContent";
-            String memberId = "testUUID";
-            String memberName = "testName";
             Post post = Post.post(PostDTO.Create.of("testContent", "testUUID", "testName"));
 
             //then

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/domain/dto/PostDTOTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/domain/dto/PostDTOTest.java
@@ -15,7 +15,7 @@ class PostDTOTest {
         PostDTO.MemberInfoDTO memberInfoDTO = new PostDTO.MemberInfoDTO(memberId, memberEmail);
 
         assertEquals(memberId, memberInfoDTO.getMemberId());
-        assertEquals(memberEmail, memberInfoDTO.getMemberName());
+        assertEquals(memberEmail, memberInfoDTO.getMemberEmail());
     }
 
     @Test
@@ -28,21 +28,6 @@ class PostDTOTest {
 
         assertEquals(content, create.getContent());
         assertEquals(memberId, create.getOwner().getMemberId());
-        assertEquals(memberName, create.getOwner().getMemberName());
-    }
-
-    @Test
-    void update() {
-        Long id = 1L;
-        String content = "testContent";
-        String memberId = "testUUID";
-        String memberName = "testName";
-
-        PostDTO.Update update = PostDTO.Update.of(id, content, memberId, memberName);
-
-        assertEquals(id, update.getId());
-        assertEquals(content, update.getContent());
-        assertEquals(memberId, update.getOwner().getMemberId());
-        assertEquals(memberName, update.getOwner().getMemberName());
+        assertEquals(memberName, create.getOwner().getMemberEmail());
     }
 }


### PR DESCRIPTION
### 변경사항

- 미사용 DTO 모델 제거
- MemberInfo 에서 MemberName -> MemberEmail 받는 것으로 변경
   *PR리뷰 주신 부분을 고려해보면 이 부분은 나중에 MemberInfo는 id만 두고 WebClient로 정보를 받아오도록 변경해야 할 것 같습니다.
- null 관리 코드 추가