### PR TITLE
[57-Little-SNS-도메인-4차] owner 관련 정보 MemberInfo클래스와 분리

### DIFF
--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/LikeMemberInfo.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/LikeMemberInfo.java
@@ -10,11 +10,11 @@ import lombok.Setter;
 @Getter
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
-public final class MemberInfo {
+public final class LikeMemberInfo {
     private final String memberId;
     private final String MemberEmail;
 
-    public MemberInfo(String memberId, String MemberEmail) {
+    public LikeMemberInfo(String memberId, String MemberEmail) {
         if (memberId == null) throw new PostException(PostException.NO_MEMBER_ID_VALUE);
         if (MemberEmail == null) throw new PostException(PostException.NO_MEMBER_EMAIL_VALUE);
 

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/Post.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/Post.java
@@ -14,19 +14,23 @@ public final class Post {
     private final String contents;
 
     @Getter
-    private final MemberInfo owner;
+    private final String ownerId;
 
     @Getter
-    private List<MemberInfo> likes = List.of();
+    private final String ownerEmail;
+
+    @Getter
+    private List<LikeMemberInfo> likes = List.of();
 
     private final Long postId;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    private Post(String contents, MemberInfo owner, List<MemberInfo> likes, boolean isCreating) {
+    private Post(String contents, String ownerId, String ownerEmail, List<LikeMemberInfo> likes, boolean isCreating) {
         if (isCreating) {
             this.contents = contents;
-            this.owner = owner;
+            this.ownerId = ownerId;
+            this.ownerEmail = ownerEmail;
             this.likes = likes;
             this.createdAt = null;
             this.updatedAt = null;
@@ -37,16 +41,18 @@ public final class Post {
     }
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Post(String contents, MemberInfo owner, Long postId, LocalDateTime createdAt, LocalDateTime updatedAt, List<MemberInfo> likes) {
+    private Post(String contents, String ownerId, String ownerEmail, Long postId, LocalDateTime createdAt, LocalDateTime updatedAt, List<LikeMemberInfo> likes) {
         if (contents == null) throw new PostException(PostException.NO_CONTENT_VALUE);
-        if (owner == null) throw new PostException(PostException.NO_OWNER_VALUE);
+        if (ownerId == null) throw new PostException(PostException.NO_OWNER_ID_VALUE);
+        if (ownerEmail == null) throw new PostException(PostException.NO_OWNER_EMAIL_VALUE);
         if (postId == null) throw new PostException(PostException.NO_POST_ID_VALUE);
         if (createdAt == null) throw new PostException(PostException.NO_CREATED_AT_VALUE);
         if (updatedAt == null) throw new PostException(PostException.NO_UPDATED_AT_VALUE);
         if (likes == null) throw new PostException(PostException.NO_LIKES_VALUE);
 
         this.contents = contents;
-        this.owner = owner;
+        this.ownerId = ownerId;
+        this.ownerEmail = ownerEmail;
         this.postId = postId;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -54,7 +60,7 @@ public final class Post {
     }
 
     public static Post post(PostDTO.Create dto) {
-        return new Post(dto.getContent(), new MemberInfo(dto.getOwner().getMemberId(), dto.getOwner().getMemberEmail()), List.of(), true);
+        return new Post(dto.getContent(), dto.getOwnerId(), dto.getOwnerEmail(), List.of(), true);
     }
 
     public Long getPostId() {

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/dto/PostDTO.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/dto/PostDTO.java
@@ -19,10 +19,11 @@ public class PostDTO {
     @RequiredArgsConstructor
     public static final class Create {
         private final String content;
-        private final MemberInfoDTO owner; //todo: 사실상 Like
+        private final String ownerId;
+        private final String ownerEmail;
 
-        public static Create of(String content, String memberId, String memberEmail) {
-            return new Create(content, new MemberInfoDTO(memberId, memberEmail));
+        public static Create of(String content, String ownerId, String ownerEmail) {
+            return new Create(content, ownerId, ownerEmail);
         }
     }
 

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/exception/PostException.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/exception/PostException.java
@@ -5,7 +5,8 @@ public class PostException extends RuntimeException {
     public static String NOT_POSTING_REQUEST = "포스트 등록 요청이 아닙니다.";
 
     public static String NO_CONTENT_VALUE = "포스트 내용이 없습니다.";
-    public static String NO_OWNER_VALUE = "포스트 소유자가 없습니다.";
+    public static String NO_OWNER_ID_VALUE = "포스트 소유자 아이디가 없습니다.";
+    public static String NO_OWNER_EMAIL_VALUE = "포스트 소유자 이메일이 없습니다.";
     public static String NO_POST_ID_VALUE = "포스트 아이디가 없습니다.";
     public static String NO_CREATED_AT_VALUE = "포스트 생성일이 없습니다.";
     public static String NO_UPDATED_AT_VALUE = "포스트 수정일이 없습니다.";

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/domain/LikeMemberInfoTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/domain/LikeMemberInfoTest.java
@@ -4,14 +4,14 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class MemberInfoTest {
+class LikeMemberInfoTest {
 
     @Test
     void memberInfo() {
         String memberId = "testUUID";
         String memberName = "testName";
 
-        MemberInfo memberInfo = new MemberInfo(memberId, memberName);
+        LikeMemberInfo memberInfo = new LikeMemberInfo(memberId, memberName);
 
         assertEquals(memberId, memberInfo.getMemberId());
         assertEquals(memberName, memberInfo.getMemberEmail());

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/domain/PostTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/domain/PostTest.java
@@ -32,8 +32,8 @@ class PostTest {
 
             //then
             assertEquals(contents, post.getContents());
-            assertEquals(memberId, post.getOwner().getMemberId());
-            assertEquals(memberName, post.getOwner().getMemberEmail());
+            assertEquals(memberId, post.getOwnerId());
+            assertEquals(memberName, post.getOwnerEmail());
         }
 
         @Test
@@ -42,13 +42,13 @@ class PostTest {
             try {
                 //given
                 Class<Post> clazz = Post.class;
-                Constructor<Post> constructorForPosting = clazz.getDeclaredConstructor(String.class, MemberInfo.class, List.class, boolean.class);
+                Constructor<Post> constructorForPosting = clazz.getDeclaredConstructor(String.class, LikeMemberInfo.class, List.class, boolean.class);
                 constructorForPosting.setAccessible(true);
 
                 //when
-                Post post = constructorForPosting.newInstance("testContent", new MemberInfo("testUUID", "testName"), List.of(), true);
+                Post post = constructorForPosting.newInstance("testContent", new LikeMemberInfo("testUUID", "testName"), List.of(), true);
                 Exception ex = assertThrows(InvocationTargetException.class, () -> {
-                    constructorForPosting.newInstance("testContent", new MemberInfo("testUUID", "testName"), List.of(), false);
+                    constructorForPosting.newInstance("testContent", new LikeMemberInfo("testUUID", "testName"), List.of(), false);
                 });
 
                 //then;

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/domain/dto/PostDTOTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/domain/dto/PostDTOTest.java
@@ -27,7 +27,7 @@ class PostDTOTest {
         PostDTO.Create create = PostDTO.Create.of(content, memberId, memberName);
 
         assertEquals(content, create.getContent());
-        assertEquals(memberId, create.getOwner().getMemberId());
-        assertEquals(memberName, create.getOwner().getMemberEmail());
+        assertEquals(memberId, create.getOwnerId());
+        assertEquals(memberName, create.getOwnerEmail());
     }
 }


### PR DESCRIPTION
### 변경사항

- owner의 정보는 Like한 맴버와 같은 테이블에 들어가서 관리할 경우 join에 문제가 생기게 되어 분리하였습니다. 
- 이에 MemberInfo클래스도 더 특정 할 수 있도록 LikeMemberInfo로 변경하였습니다.