### PR TITLE
[Experiment-02-r2dbc-에서-애그리거트-관리]

### DIFF
--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/LikeMemberInfo.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/LikeMemberInfo.java
@@ -1,6 +1,7 @@
 package com.littleSNSMS.domain;
 
 import com.littleSNSMS.domain.exception.PostException;
+import com.littleSNSMS.infra.db.entities.LikeMemberInfoEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,5 +21,10 @@ public final class LikeMemberInfo {
 
         this.memberId = memberId;
         this.MemberEmail = MemberEmail;
+    }
+
+    public static LikeMemberInfo from(LikeMemberInfoEntity likeMemberInfoEntity) {
+        return new LikeMemberInfo(likeMemberInfoEntity.getMemberId(), likeMemberInfoEntity.getMemberEmail());
+
     }
 }

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/Post.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/Post.java
@@ -2,6 +2,8 @@ package com.littleSNSMS.domain;
 
 import com.littleSNSMS.domain.dto.PostDTO;
 import com.littleSNSMS.domain.exception.PostException;
+import com.littleSNSMS.infra.db.entities.LikeMemberInfoEntity;
+import com.littleSNSMS.infra.db.entities.PostEntity;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -61,6 +63,18 @@ public final class Post {
 
     public static Post post(PostDTO.Create dto) {
         return new Post(dto.getContent(), dto.getOwnerId(), dto.getOwnerEmail(), List.of(), true);
+    }
+
+    public static Post of(PostEntity postEntity, List<LikeMemberInfoEntity> LikeMemberInfoEntities) {
+        return Post.builder()
+                .contents(postEntity.getContents())
+                .ownerId(postEntity.getOwnerId())
+                .ownerEmail(postEntity.getOwnerEmail())
+                .postId(postEntity.getPostId())
+                .createdAt(postEntity.getCreatedAt())
+                .updatedAt(postEntity.getUpdatedAt())
+                .likes(LikeMemberInfoEntities.stream().map(LikeMemberInfo::from).toList())
+                .build();
     }
 
     public Long getPostId() {

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/domain/PostReactiveRepository.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/domain/PostReactiveRepository.java
@@ -1,7 +1,10 @@
 package com.littleSNSMS.domain;
 
+import com.littleSNSMS.domain.dto.PostDTO;
 import reactor.core.publisher.Mono;
 
 public interface PostReactiveRepository {
     Mono<Long> save(Post post);
+
+    Mono<Void> likePost(Long postId, LikeMemberInfo likeMemberInfo);
 }

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/infra/db/entities/LikeMemberInfoEntity.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/infra/db/entities/LikeMemberInfoEntity.java
@@ -21,8 +21,6 @@ public class LikeMemberInfoEntity {
             throw new PostEntityException(PostEntityException.NO_LIKE_MEMBER_INFO_ENTITY_MEMBER_ID_VALUE);
         if (memberEmail == null)
             throw new PostEntityException(PostEntityException.NO_LIKE_MEMBER_INFO_ENTITY_MEMBER_EMAIL_VALUE);
-
-
         this.postId = postId;
         this.memberId = memberId;
         this.memberEmail = memberEmail;

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/infra/db/entities/PostEntity.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/infra/db/entities/PostEntity.java
@@ -74,6 +74,10 @@ public class PostEntity {
         return new PostEntity(post.getContents(), post.getOwnerId(), post.getOwnerEmail(), true);
     }
 
+    public Post toPost(List<LikeMemberInfoEntity> likeMemberInfoEntities) {
+        return Post.of(this, likeMemberInfoEntities);
+    }
+
     //test
     public static PostEntity postedForTest() {
         return PostEntity.builder()

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/infra/db/repository/PostR2dbcRepository.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/infra/db/repository/PostR2dbcRepository.java
@@ -1,11 +1,19 @@
 package com.littleSNSMS.infra.db.repository;
 
+import com.littleSNSMS.infra.db.entities.LikeMemberInfoEntity;
 import com.littleSNSMS.infra.db.entities.PostEntity;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface PostR2dbcRepository extends R2dbcRepository<PostEntity, Long> {
 
-//    @Query("INSERT INTO member_info (member_id, member_email) VALUES (:memberId, :memberEmail) RETURNING *")
-//    MemberInfoEntity like(Long postId, MemberInfoEntity memberInfoEntity);
+    @Query("INSERT INTO like_member_info (post_id, member_id, member_email) VALUES (:postId, :memberId, :memberEmail); " +
+            "SELECT * FROM like_member_info WHERE post_id = :postId AND member_id = :memberId")
+    Mono<LikeMemberInfoEntity> likePost(Long postId, String memberId, String memberEmail);
+
+    @Query("SELECT * FROM like_member_info WHERE post_id = :postId")
+    Flux<LikeMemberInfoEntity> findLikeMemberInfo(Long postId);
 }
 

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/infra/db/repository/PostReactiveRepositoryImpl.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/infra/db/repository/PostReactiveRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.littleSNSMS.infra.db.repository;
 
+import com.littleSNSMS.domain.LikeMemberInfo;
 import com.littleSNSMS.domain.Post;
 import com.littleSNSMS.domain.PostReactiveRepository;
+import com.littleSNSMS.infra.db.entities.LikeMemberInfoEntity;
 import com.littleSNSMS.infra.db.entities.PostEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,6 +18,20 @@ public class PostReactiveRepositoryImpl implements PostReactiveRepository {
     @Override
     public Mono<Long> save(Post post) {
         return postR2dbcRepository.save(PostEntity.post(post)).map(PostEntity::getPostId);
+    }
+
+    @Override
+    public Mono<Void> likePost(Long postId, LikeMemberInfo likeMemberInfo) {
+        postR2dbcRepository.likePost(postId, likeMemberInfo.getMemberEmail(), likeMemberInfo.getMemberId());
+        return Mono.empty(); //todo: 에러 처리.
+    }
+
+    public Mono<Post> findById(Long postId) {
+        return postR2dbcRepository.findById(postId).flatMap(postEntity -> {
+            return postR2dbcRepository.findLikeMemberInfo(postId).collectList().map(likeMemberInfoEntities -> {
+                return postEntity.toPost(likeMemberInfoEntities);
+            });
+        });
     }
 
 }

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/runner.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/runner.java
@@ -1,0 +1,63 @@
+package com.littleSNSMS;
+
+import com.littleSNSMS.domain.Post;
+import com.littleSNSMS.domain.dto.PostDTO;
+import com.littleSNSMS.infra.db.entities.LikeMemberInfoEntity;
+import com.littleSNSMS.infra.db.entities.PostEntity;
+import com.littleSNSMS.infra.db.repository.PostR2dbcRepository;
+import com.littleSNSMS.infra.db.repository.PostReactiveRepositoryImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+// 임시적으로 테스트를 위해 있는 클래스 입니다. 추후 삭제 예정입니다.
+public class runner implements CommandLineRunner {
+
+    private final PostR2dbcRepository postRepository;
+    //private final EntRepo entRepo;
+
+    private final PostReactiveRepositoryImpl reactiveRepo;
+
+    @Override
+    //   @Transactional
+    public void run(String... args) throws Exception {
+        PostDTO.Create create = PostDTO.Create.of("Hello world!", "ID", "name");
+        Post post = Post.post(create);
+        PostEntity postEntity = PostEntity.post(post);
+        Long id = postRepository.save(postEntity).block().getPostId();
+        System.out.println("saved");
+        System.out.println("id = " + id);
+
+        LikeMemberInfoEntity like = postRepository.likePost(id, "memberId", "memberEmail2").block();
+        System.out.println("liked");
+        System.out.println(like.getMemberEmail());
+
+        LikeMemberInfoEntity like2 = postRepository.likePost(id, "memberId2", "memberEmail3").block();
+        System.out.println("liked2");
+        System.out.println(like2.getMemberEmail());
+
+        List<LikeMemberInfoEntity> list = postRepository.findLikeMemberInfo(id).collectList().block();
+
+        System.out.println("find");
+        for (LikeMemberInfoEntity likeMemberInfoEntity : list) {
+            System.out.println(likeMemberInfoEntity.getMemberEmail());
+        }
+
+        Post post2 = reactiveRepo.findById(id).block();
+        System.out.println("find2");
+        System.out.println(post2.getPostId());
+        System.out.println(post2.getContents());
+        System.out.println(post2.getOwnerId());
+        System.out.println(post2.getOwnerEmail());
+        System.out.println(post2.getCreatedAt());
+        System.out.println(post2.getUpdatedAt());
+        for (int i = 0; i < post2.getLikes().size(); i++) {
+            System.out.println(post2.getLikes().get(i).getMemberEmail());
+        }
+
+    }
+}

--- a/little-SNS-MS/src/main/resources/application.yml
+++ b/little-SNS-MS/src/main/resources/application.yml
@@ -3,6 +3,12 @@ spring:
     url: r2dbc:mysql://localhost:3306/sns
     username: root
     password: 1234
+logging:
+  level:
+    org.springframework.r2dbc: DEBUG
+    io.r2dbc.pool: DEBUG
+    io.asyncer.r2dbc.mysql: DEBUG
+    io.asyncer.r2dbc.mysql.QUERY: DEBUG
   sql:
     init:
       mode: always

--- a/little-SNS-MS/src/main/resources/db/schema.sql
+++ b/little-SNS-MS/src/main/resources/db/schema.sql
@@ -10,7 +10,8 @@ CREATE TABLE IF NOT EXISTS sns.post (
     updated_at TIMESTAMP
 );
 
-CREATE TABLE IF NOT EXISTS sns.member_info(
-    member_id BIGINT,
-    member_name VARCHAR(255)
+CREATE TABLE IF NOT EXISTS sns.like_member_info(
+    post_id BIGINT,
+    member_id VARCHAR(255),
+    member_email VARCHAR(255)
 );


### PR DESCRIPTION
### 변경사항

- DDD 관점에서 볼때 LikeMemberInfo는 Post라는 애그리거트루트에서 관리되어야 하는 값객체 입니다. 그러나, r2dbc는 ORM이 아니라 Post에 속하는 LikeMemberInfo를 따로 저장해 주지 않습니다. 
- 그래서 LikeMemberInfo 관련 리포지토리를 만들거나, 지금처럼 네이티브 쿼리로 테이블에 저장하고 이후에 값을 넣어 주어야 합니다. 
- Q. 저는 Post의 리포지토리에서 애그리거트의 트랜잭션의 정합성을 책임지는게 맞다고 생각해서 네이티브 쿼리로 작성했는데, LikeMemberInfo의 리포지토리를 사용하는 것이 더 편리하고 직관적인 방법이라, 너무 DDD의 설계에 맞추기 위해 오버엔지니어링을 한건가 의문이 들어서 간단히 구현하여 의견을 여쭈어 보고 싶습니다. 