### PR TITLE
[59-카프카-consumer-2차]

### DIFF
--- a/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/kafka/config/AlarmEventConsumerConfig.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/kafka/config/AlarmEventConsumerConfig.java
@@ -1,0 +1,41 @@
+package com.membercontext.memberAPI.infrastructure.kafka.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.kafka.ConcurrentKafkaListenerContainerFactoryConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+@EnableKafka
+@Slf4j
+public class AlarmEventConsumerConfig {
+
+    public DefaultErrorHandler errorHandler() {
+
+        FixedBackOff fixedBackOff = new FixedBackOff(1000L, 2);
+
+        return new DefaultErrorHandler(fixedBackOff);
+    }
+
+    @Bean
+    ConcurrentKafkaListenerContainerFactory<?, ?> kafkaListenerContainerFactory(
+            ConcurrentKafkaListenerContainerFactoryConfigurer configurer,
+            ConsumerFactory<Object, Object> kafkaConsumerFactory) {
+
+        ConcurrentKafkaListenerContainerFactory<Object, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        configurer.configure(factory, kafkaConsumerFactory);
+        factory.setConcurrency(3);
+        factory.setCommonErrorHandler(errorHandler());
+        System.out.println("upupup");
+        return factory;
+    }
+}
+
+
+
+

--- a/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/kafka/consumer/AlarmEventConsumer.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/kafka/consumer/AlarmEventConsumer.java
@@ -1,7 +1,10 @@
 package com.membercontext.memberAPI.infrastructure.kafka.consumer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.membercontext.memberAPI.infrastructure.kafka.consumer.record.HelpAlarmEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -9,9 +12,17 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class AlarmEventConsumer {
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @KafkaListener(topics = {"alarm-events"}
             , groupId = "alarm-events-listener-group")
     public void onMessage(ConsumerRecord<Integer, String> consumerRecord) {
         log.info("ConsumerRecord : {}", consumerRecord);
+        try {
+            HelpAlarmEvent helpAlarmEvent = objectMapper.readValue(consumerRecord.value(), HelpAlarmEvent.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/kafka/consumer/record/HelpAlarmEvent.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/infrastructure/kafka/consumer/record/HelpAlarmEvent.java
@@ -1,0 +1,26 @@
+package com.membercontext.memberAPI.infrastructure.kafka.consumer.record;
+
+import com.membercontext.memberAPI.web.controller.AlarmController;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
+public final class HelpAlarmEvent {
+    private final Long alarmEventId;
+    private final AlarmController.AlarmRequest alarmRequest;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public HelpAlarmEvent(Long alarmEventId, AlarmController.AlarmRequest alarmRequest) {
+        if (alarmEventId == null || alarmRequest == null) throw new IllegalArgumentException("should not be null");
+        this.alarmEventId = alarmEventId;
+        this.alarmRequest = alarmRequest; //todo: alarmRequest가 null이면 어떻게 처리할지 결정.
+    }
+
+    //test
+    public static HelpAlarmEvent createForTest() {
+        return HelpAlarmEvent.builder()
+                .alarmEventId(1L)
+                .alarmRequest(AlarmController.AlarmRequest.createForTest())
+                .build();
+    }
+}

--- a/member-context/src/main/java/com/membercontext/memberAPI/web/controller/AlarmController.java
+++ b/member-context/src/main/java/com/membercontext/memberAPI/web/controller/AlarmController.java
@@ -48,6 +48,16 @@ public class AlarmController {
 
         @NotBlank(message = ALARM_MESSAGE_NOT_FOUND)
         private final String message;
+
+        //test
+        public static AlarmRequest createForTest() {
+            return AlarmRequest.builder()
+                    .x(1.0)
+                    .y(1.0)
+                    .title("title")
+                    .message("message")
+                    .build();
+        }
     }
 
 

--- a/member-context/src/main/resources/application.yml
+++ b/member-context/src/main/resources/application.yml
@@ -23,8 +23,8 @@ spring:
       auto-offset-reset: latest
     producer:
       bootstrap-servers:
-        #        -   localhost:9092,localhost:9093,localhost:9094
-        - kafkaA:19092
+        - localhost:9092,localhost:9093,localhost:9094
+        #- kafkaA:19092
       key-serializer: org.apache.kafka.common.serialization.IntegerSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
 server:

--- a/member-context/src/test/java/com/membercontext/memberAPI/infrastructure/kafka/ConsumerTest.java
+++ b/member-context/src/test/java/com/membercontext/memberAPI/infrastructure/kafka/ConsumerTest.java
@@ -1,0 +1,73 @@
+package com.membercontext.memberAPI.infrastructure.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.membercontext.memberAPI.infrastructure.kafka.consumer.AlarmEventConsumer;
+import com.membercontext.memberAPI.infrastructure.kafka.consumer.record.HelpAlarmEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.ContainerTestUtils;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@EmbeddedKafka(topics = {"alarm-events"}, partitions = 3)
+@TestPropertySource(properties = {"spring.kafka.producer.bootstrap-servers=${spring.embedded.kafka.brokers}",
+        "spring.kafka.consumer.bootstrap-servers=${spring.embedded.kafka.brokers}"})
+public class ConsumerTest {
+
+    @Autowired
+    EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Autowired
+    KafkaTemplate<Integer, String> kafkaTemplate;
+
+    @Autowired
+    KafkaListenerEndpointRegistry endpointRegistry;
+
+    @SpyBean
+    private AlarmEventConsumer libraryEventsConsumerSpy;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        for (MessageListenerContainer messageListenerContainer : endpointRegistry.getListenerContainers()) {
+            ContainerTestUtils.waitForAssignment(messageListenerContainer, embeddedKafkaBroker.getPartitionsPerTopic());
+        }
+    }
+
+    @Test
+    void publishNewLibraryEvent() throws ExecutionException, InterruptedException, JsonProcessingException {
+        //given
+        HelpAlarmEvent ev = HelpAlarmEvent.createForTest();
+        String json = objectMapper.writeValueAsString(ev);
+        kafkaTemplate.sendDefault(json).get();
+
+        //when
+        CountDownLatch latch = new CountDownLatch(1);
+        latch.await(5, TimeUnit.SECONDS);
+
+        //then
+        verify(libraryEventsConsumerSpy, times(1)).onMessage(isA(ConsumerRecord.class));
+    }
+
+
+}

--- a/member-context/src/test/resources/application.yml
+++ b/member-context/src/test/resources/application.yml
@@ -12,6 +12,21 @@ spring:
       ddl-auto: none
     database-platform: org.hibernate.dialect.MySQLDialect
     generate-ddl: true
+  kafka:
+    template:
+      default-topic: alarm-events
+    consumer:
+      bootstrap-servers: kafkaA:19092,kafkaB:19093,kafkaC:19094
+      key-deserializer: org.apache.kafka.common.serialization.IntegerDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      group-id: alarm-events-listener-group
+      auto-offset-reset: latest
+    producer:
+      bootstrap-servers:
+        - localhost:9092,localhost:9093,localhost:9094
+        #- kafkaA:19092
+      key-serializer: org.apache.kafka.common.serialization.IntegerSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 server:
   port: 8080
 


### PR DESCRIPTION
### 변경사항

- 아직 공부 중이기는 하지만, Consumer의 경우에도 retry와 recover 전략을 어떻게 할지 고민을 해야하는 것같습니다. 
- 코드 레벨에서 구현하여서 검사를 받고 싶었지만, 현재 Configuration관련 코드가 왜인지 계속 작동하지 않아서 일단 관련 지식만 공부해서 멘토링 때 여쭈어 보고 구현은 이후에 하려고 합니다. 나름대로 전략을 생각해 오도록 하겠습니다. 
- 다만, 저번에 문제가 있던 Embedded Kafka 코드를 수정하여 컨슈머가 토픽을 구독하고 받은 메시지를 파싱까지 하는 것은 것은 확인하였습니다. 이후 스스로 공부하며 TestContainer로 변경하고 전략대로 하나씩 설정을 변경해 나가겠습니다.