### PR TITLE
[Hotfix-15-request를-service의-dto로-변경-little-sns]

### DIFF
--- a/little-SNS-MS/src/main/java/com/littleSNSMS/application/PostApplication.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/application/PostApplication.java
@@ -1,19 +1,22 @@
 package com.littleSNSMS.application;
 
 import com.littleSNSMS.controller.PostController;
-import com.littleSNSMS.domain.dto.PostDTO;
 import com.littleSNSMS.domain.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
 public class PostApplication {
 
-    private final PostService postService;
+    private final com.littleSNSMS.domain.service.PostService postService;
 
-    public Mono<Long> post(PostController.PostRequest req) {
-        return postService.post(PostDTO.Create.of(req.getContent(), req.getOwnerId(), req.getOwnerEmail()));
+    @Transactional
+    public Mono<Long> post(PostService.Create dto) {
+        return postService.post(PostService.Create.of(dto.getContent(), dto.getOwnerId(), dto.getOwnerEmail()));
     }
+
+
 }

--- a/little-SNS-MS/src/main/java/com/littleSNSMS/controller/PostController.java
+++ b/little-SNS-MS/src/main/java/com/littleSNSMS/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.littleSNSMS.controller;
 
 import com.littleSNSMS.application.PostApplication;
+import com.littleSNSMS.domain.service.PostService;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,19 +19,10 @@ public class PostController {
     public static final String POST_SUCCESS = "포스트 되었습니다.";
 
     @PostMapping("/post")
-    public Mono<PostResponse> post(PostRequest req) {
+    public Mono<PostResponse> post(PostService.Create req) {
         return postApplication.post(req).map(id -> {
             return PostResponse.from(POST_SUCCESS, id);
         });
-    }
-
-    @Getter
-    @NoArgsConstructor(force = true)
-    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-    public static final class PostRequest {
-        private final String content;
-        private final String ownerId;
-        private final String ownerEmail;
     }
 
     @Getter

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/application/PostApplicationTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/application/PostApplicationTest.java
@@ -26,7 +26,7 @@ class PostApplicationTest {
     @Test
     void post() {
         // Given
-        PostController.PostRequest request = mock(PostController.PostRequest.class);
+        PostService.Create request = mock(PostService.Create.class);
         when(postService.post(any(PostService.Create.class))).thenReturn(Mono.just(1L));
 
         // When

--- a/little-SNS-MS/src/test/java/com/littleSNSMS/controller/PostControllerTest.java
+++ b/little-SNS-MS/src/test/java/com/littleSNSMS/controller/PostControllerTest.java
@@ -1,6 +1,7 @@
 package com.littleSNSMS.controller;
 
 import com.littleSNSMS.application.PostApplication;
+import com.littleSNSMS.domain.service.PostService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +26,7 @@ class PostControllerTest {
     void post() {
         // Given
         String request = "{\"content\":\"content\",\"ownerId\":\"ownerId\",\"ownerEmail\":\"ownerEmail\"}";
-        Mockito.when(postApplication.post(any(PostController.PostRequest.class))).thenReturn(Mono.just(1L));
+        Mockito.when(postApplication.post(any(PostService.Create.class))).thenReturn(Mono.just(1L));
 
         // When & Then
         webTestClient.post()


### PR DESCRIPTION
### 변경사항
- Request에서 서비스의 DTO를 변경 (인터페이스의 도메인 의존)
  -  계층에 맞지 않지만 편의를 위해 불필요하게 반복되는 타입 변경 코드를 지양 하기위해 변경.