### PR TITLE
Hotfix/25 remove jpa entity dependency of domain models (check in ms)

### DIFF
--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/application/service/help/read/HelpSelectApplication.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/application/service/help/read/HelpSelectApplication.java
@@ -1,8 +1,6 @@
 package com.example.checkinrequestMS.HelpAPI.application.service.help.read;
 
-import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.CheckInService;
-import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.EtcService;
-import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.LineUpService;
+import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -15,18 +13,18 @@ public class HelpSelectApplication {
     private final LineUpService lineUpService;
     private final EtcService etcService;
 
-    @Cacheable(cacheNames = "help_searched", key = "'checkIn_' + #id")
-    public CheckInService.CheckInSelected selectCheckIn(Long id) {
+    //@Cacheable(cacheNames = "help_searched", key = "'checkIn_' + #id")
+    public CheckIn.DTO selectCheckIn(Long id) {
         return checkInService.findCheckIn(id);
     }
 
     @Cacheable(cacheNames = "help_searched", key = "'lineUp_' + #id")
-    public LineUpService.LineUpSelected selectLineUp(Long id) {
+    public LineUp.DTO selectLineUp(Long id) {
         return lineUpService.findLineUp(id);
     }
 
     @Cacheable(cacheNames = "help_searched", key = "'etc_' + #id")
-    public EtcService.EtcSelected selectEtc(Long id) {
+    public Etc.DTO selectEtc(Long id) {
         return etcService.findEtc(id);
     }
 }

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/application/service/help/write/CheckInWriteApplication.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/application/service/help/write/CheckInWriteApplication.java
@@ -1,5 +1,6 @@
 package com.example.checkinrequestMS.HelpAPI.application.service.help.write;
 
+import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.CheckIn;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.CheckInService;
 import com.example.checkinrequestMS.common.aop.testTime.TestTime;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,7 @@ public class CheckInWriteApplication {
 
     @Transactional
     @CachePut(cacheNames = "help_searched", key = "'checkIn_' + #result")
-    public CheckInService.CheckInSelected updateCheckIn(CheckInService.Update dto) {
+    public CheckIn.DTO updateCheckIn(CheckInService.Update dto) {
         return checkInService.update(dto);
     }
 

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/HelpDetail.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/HelpDetail.java
@@ -1,6 +1,5 @@
 package com.example.checkinrequestMS.HelpAPI.domain.model.help;
 
-import com.example.checkinrequestMS.HelpAPI.infra.db.entity.HelpDetailEntity;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -47,7 +46,7 @@ public final class HelpDetail {
                 .build();
     }
 
-    public static HelpDetail toDomain(HelpDetailEntity entity) {
+    public static HelpDetail from(DTO entity) {
         return HelpDetail.builder()
                 .helpRegisterId(entity.getHelpRegisterId())
                 .title(entity.getTitle())
@@ -68,6 +67,20 @@ public final class HelpDetail {
                 .placeId("placeId")
                 .reward(100L)
                 .build();
+    }
+
+    public interface DTO {
+        Long getHelpRegisterId();
+
+        String getTitle();
+
+        LocalDateTime getStart();
+
+        LocalDateTime getEnd();
+
+        String getPlaceId();
+
+        Long getReward();
     }
 
     public interface Registration {

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/Progress.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/Progress.java
@@ -2,7 +2,6 @@ package com.example.checkinrequestMS.HelpAPI.domain.model.help;
 
 import com.example.checkinrequestMS.HelpAPI.domain.exceptions.help.HelpErrorCode;
 import com.example.checkinrequestMS.HelpAPI.domain.exceptions.help.HelpException;
-import com.example.checkinrequestMS.HelpAPI.infra.db.entity.ProgressEntity;
 import lombok.*;
 
 import java.util.Optional;
@@ -37,14 +36,23 @@ public final class Progress {
         return new Progress(Progress.ProgressStatus.ONGOING, Optional.of(helperId), this.photoPath, this.completed);
     }
 
-
-    public static Progress toDomain(ProgressEntity progress) {
+    public static Progress from(DTO progress) {
         return new Progress(progress.getStatus(), progress.getHelperId(), progress.getPhotoPath(), progress.isCompleted());
     }
 
     //For Test
     public static Progress createForTest() {
         return Progress.DEFAULT;
+    }
+
+    public interface DTO {
+        ProgressStatus getStatus();
+
+        Optional<Long> getHelperId();
+
+        Optional<String> getPhotoPath();
+
+        boolean isCompleted();
     }
 
     @Getter

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/CheckIn.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/CheckIn.java
@@ -2,8 +2,10 @@ package com.example.checkinrequestMS.HelpAPI.domain.model.help.child;
 
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.HelpDetail;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.Progress;
-import com.example.checkinrequestMS.HelpAPI.infra.db.entity.child.CheckInEntity;
 import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Getter
 @Setter(AccessLevel.PRIVATE)
@@ -13,7 +15,9 @@ public final class CheckIn {
     public static final String CHECK_IN_TITLE = "체크인 요청";
 
     private final Long id;
+    @Getter(AccessLevel.PRIVATE)
     private final HelpDetail helpDetail;
+    @Getter(AccessLevel.PRIVATE)
     private final Progress progress;
 
 
@@ -51,20 +55,59 @@ public final class CheckIn {
                 .build();
     }
 
-    public static CheckIn transferFrom(CheckInEntity entity) {
+    public static CheckIn from(DTO entity) {
         return CheckIn.builder()
                 .id(entity.getId())
-                .helpDetail(HelpDetail.toDomain(entity.getHelpEntity()))
-                .progress(Progress.toDomain(entity.getProgressEntity()))
+                .helpDetail(HelpDetail.from(entity))
+                .progress(Progress.from(entity))
                 .build();
     }
 
-    public HelpDetail getHelpEntityToPersist() {
-        return this.helpDetail;
-    }
+    @Getter
+    public static final class DTO implements HelpDetail.DTO, Progress.DTO {
+        private final Long id;
+        private final Long helpRegisterId;
+        private final String title;
+        private final LocalDateTime start;
+        private final LocalDateTime end;
+        private final String placeId;
+        private final Long reward;
+        private final Progress.ProgressStatus status;
+        private final Optional<Long> helperId;
+        private final Optional<String> photoPath;
+        private final boolean completed;
 
-    public Progress getProgressEntityToPersist() {
-        return this.progress;
+        @Builder
+        public DTO(Long id, Long helpRegisterId, String title, LocalDateTime start, LocalDateTime end, String placeId, Long reward, Progress.ProgressStatus status, Optional<Long> helperId, Optional<String> photoPath, boolean completed) {
+            // fixme: null 처리
+            this.id = id;
+            this.helpRegisterId = helpRegisterId;
+            this.title = title;
+            this.start = start;
+            this.end = end;
+            this.placeId = placeId;
+            this.reward = reward;
+            this.status = status;
+            this.helperId = helperId;
+            this.photoPath = photoPath;
+            this.completed = completed;
+        }
+
+        public static CheckIn.DTO getDTO(CheckIn checkIn) {
+            return CheckIn.DTO.builder()
+                    .id(checkIn.getId())
+                    .helpRegisterId(checkIn.getHelpDetail().getHelpRegisterId())
+                    .title(checkIn.getHelpDetail().getTitle())
+                    .start(checkIn.getHelpDetail().getStart())
+                    .end(checkIn.getHelpDetail().getEnd())
+                    .placeId(checkIn.getHelpDetail().getPlaceId())
+                    .reward(checkIn.getHelpDetail().getReward())
+                    .status(checkIn.getProgress().getStatus())
+                    .helperId(checkIn.getProgress().getHelperId())
+                    .photoPath(checkIn.getProgress().getPhotoPath())
+                    .completed(checkIn.getProgress().isCompleted())
+                    .build();
+        }
     }
 
     //for Test
@@ -75,5 +118,4 @@ public final class CheckIn {
                 .progress(Progress.createForTest())
                 .build();
     }
-
 }

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/CheckInService.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/CheckInService.java
@@ -2,7 +2,6 @@ package com.example.checkinrequestMS.HelpAPI.domain.model.help.child;
 
 import com.example.checkinrequestMS.HelpAPI.application.service.alarm.AlarmService;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.HelpDetail;
-import com.example.checkinrequestMS.HelpAPI.domain.model.help.Progress;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.stereotype.Service;
@@ -28,14 +27,14 @@ public class CheckInService {
         return checkInRepository.save(checkIn);
     }
 
-    public CheckInSelected findCheckIn(Long id) {
-        return CheckInSelected.createResponse(checkInRepository.findById(id));
+    public CheckIn.DTO findCheckIn(Long id) {
+        return CheckIn.DTO.getDTO(checkInRepository.findById(id));
     }
 
-    public CheckInSelected update(Update dto) {
+    public CheckIn.DTO update(Update dto) {
         CheckIn checkIn = checkInRepository.findById(dto.getHelpId());
         checkIn.update(dto);
-        return CheckInSelected.createResponse(checkInRepository.update(checkIn));
+        return CheckIn.DTO.getDTO(checkInRepository.update(checkIn));
     }
 
     public Long startCheckIn(@NonNull CheckInStarted dto) {
@@ -202,35 +201,6 @@ public class CheckInService {
             return CheckInStarted.builder()
                     .checkInId(1L)
                     .helperId(1L)
-                    .build();
-        }
-    }
-
-    // DTO - Response
-    @Getter
-    @NoArgsConstructor(force = true)
-    public static final class CheckInSelected {
-
-        private final Long checkInId;
-
-        private final HelpDetail.HelpDetailSelected helpDetail;
-
-        private final Progress.ProgressSelected progress;
-
-        @Builder(access = AccessLevel.PRIVATE)
-        public CheckInSelected(@NonNull Long checkInId,
-                               @NonNull HelpDetail.HelpDetailSelected helpDetail,
-                               @NonNull Progress.ProgressSelected progress) {
-            this.checkInId = checkInId;
-            this.helpDetail = helpDetail;
-            this.progress = progress;
-        }
-
-        public static CheckInSelected createResponse(CheckIn checkIn) {
-            return CheckInSelected.builder()
-                    .checkInId(checkIn.getId())
-                    .helpDetail(HelpDetail.HelpDetailSelected.createResponse(checkIn.getHelpDetail()))
-                    .progress(Progress.ProgressSelected.createResponse(checkIn.getProgress()))
                     .build();
         }
     }

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/Etc.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/Etc.java
@@ -2,11 +2,13 @@ package com.example.checkinrequestMS.HelpAPI.domain.model.help.child;
 
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.HelpDetail;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.Progress;
-import com.example.checkinrequestMS.HelpAPI.infra.db.entity.child.EtcEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 
 @Getter
@@ -14,7 +16,9 @@ public final class Etc {
 
     private final Long id;
     private final String contents;
+    @Getter(AccessLevel.PRIVATE)
     private final HelpDetail helpDetail;
+    @Getter(AccessLevel.PRIVATE)
     private final Progress progress;
 
     @Builder(access = AccessLevel.PRIVATE)
@@ -54,14 +58,65 @@ public final class Etc {
                 .build();
     }
 
-    public static Etc transferFrom(EtcEntity entity) {
+    public static Etc from(DTO dto) {
         return Etc.builder()
-                .id(entity.getId())
-                .contents(entity.getContents())
-                .helpDetail(HelpDetail.toDomain(entity.getHelpEntity()))
-                .progress(Progress.toDomain(entity.getProgressEntity()))
+                .id(dto.getId())
+                .contents(dto.getContents())
+                .helpDetail(HelpDetail.from(dto))
+                .progress(Progress.from(dto))
                 .build();
     }
+
+    @Getter
+    public static final class DTO implements HelpDetail.DTO, Progress.DTO {
+        private final Long id;
+        private final String contents;
+        private final Long helpRegisterId;
+        private final String title;
+        private final LocalDateTime start;
+        private final LocalDateTime end;
+        private final String placeId;
+        private final Long reward;
+        private final Progress.ProgressStatus status;
+        private final Optional<Long> helperId;
+        private final Optional<String> photoPath;
+        private final boolean completed;
+
+        @Builder
+        public DTO(Long id, String contents, Long helpRegisterId, String title, LocalDateTime start, LocalDateTime end, String placeId, Long reward, Progress.ProgressStatus status, Optional<Long> helperId, Optional<String> photoPath, boolean completed) {
+            // fixme: null 처리
+            this.id = id;
+            this.contents = contents;
+            this.helpRegisterId = helpRegisterId;
+            this.title = title;
+            this.start = start;
+            this.end = end;
+            this.placeId = placeId;
+            this.reward = reward;
+            this.status = status;
+            this.helperId = helperId;
+            this.photoPath = photoPath;
+            this.completed = completed;
+        }
+
+        public static Etc.DTO getDTO(Etc etc) {
+            return DTO.builder()
+                    .id(etc.getId())
+                    .contents(etc.getContents())
+                    .helpRegisterId(etc.getHelpDetail().getHelpRegisterId())
+                    .title(etc.getHelpDetail().getTitle())
+                    .start(etc.getHelpDetail().getStart())
+                    .end(etc.getHelpDetail().getEnd())
+                    .placeId(etc.getHelpDetail().getPlaceId())
+                    .reward(etc.getHelpDetail().getReward())
+                    .status(etc.getProgress().getStatus())
+                    .helperId(etc.getProgress().getHelperId())
+                    .photoPath(etc.getProgress().getPhotoPath())
+                    .completed(etc.getProgress().isCompleted())
+                    .build();
+        }
+    }
+
 
     //for Test
     public static Etc createForTest() {

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/EtcService.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/EtcService.java
@@ -2,7 +2,6 @@ package com.example.checkinrequestMS.HelpAPI.domain.model.help.child;
 
 import com.example.checkinrequestMS.HelpAPI.application.service.alarm.AlarmService;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.HelpDetail;
-import com.example.checkinrequestMS.HelpAPI.domain.model.help.Progress;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.stereotype.Service;
@@ -27,14 +26,14 @@ public class EtcService {
         return etcRepository.save(etc);
     }
 
-    public EtcSelected findEtc(Long id) {
-        return EtcSelected.createResponse(etcRepository.findById(id));
+    public Etc.DTO findEtc(Long id) {
+        return Etc.DTO.getDTO(etcRepository.findById(id));
     }
 
-    public EtcSelected updateEtc(Update dto) {
+    public Etc.DTO updateEtc(Update dto) {
         Etc etc = etcRepository.findById(dto.getHelpId());
-        etc.update(dto);
-        return EtcSelected.createResponse(etcRepository.update(etc));
+        etc.update(dto); //fixme: ??
+        return Etc.DTO.getDTO(etcRepository.update(etc));
     }
 
     public Long startEtc(@NonNull EtcStarted dto) {
@@ -201,38 +200,6 @@ public class EtcService {
                     .start(LocalDateTime.now())
                     .option(10)
                     .reward(100L)
-                    .build();
-        }
-    }
-
-    @Getter
-    @NoArgsConstructor(force = true)
-    public static final class EtcSelected {
-
-        private final Long etcId;
-
-        private final String contents;
-
-        private final HelpDetail.HelpDetailSelected helpDetail;
-
-        private final Progress.ProgressSelected progress;
-
-        @Builder(access = AccessLevel.PRIVATE)
-        public EtcSelected(@NonNull Long etcId, @NonNull String contents,
-                           @NonNull HelpDetail.HelpDetailSelected helpDetail,
-                           @NonNull Progress.ProgressSelected progress) {
-            this.etcId = etcId;
-            this.contents = contents;
-            this.helpDetail = helpDetail;
-            this.progress = progress;
-        }
-
-        public static EtcService.EtcSelected createResponse(Etc etc) {
-            return EtcSelected.builder()
-                    .etcId(etc.getId())
-                    .contents(etc.getContents())
-                    .helpDetail(HelpDetail.HelpDetailSelected.createResponse(etc.getHelpDetail()))
-                    .progress(Progress.ProgressSelected.createResponse(etc.getProgress()))
                     .build();
         }
     }

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/LineUp.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/LineUp.java
@@ -2,11 +2,13 @@ package com.example.checkinrequestMS.HelpAPI.domain.model.help.child;
 
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.HelpDetail;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.Progress;
-import com.example.checkinrequestMS.HelpAPI.infra.db.entity.child.LineUpEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 
 @Getter
@@ -15,7 +17,9 @@ public final class LineUp {
     public static final String CHECK_IN_TITLE = "체크인 요청";
 
     private final Long id;
+    @Getter(AccessLevel.PRIVATE)
     private final HelpDetail helpDetail;
+    @Getter(AccessLevel.PRIVATE)
     private final Progress progress;
 
     @Builder(access = AccessLevel.PRIVATE)
@@ -51,13 +55,60 @@ public final class LineUp {
                 .progress(this.progress.registerHelper(helperId))
                 .build();
     }
-    
-    public static LineUp transferFrom(LineUpEntity entity) {
+
+    public static LineUp from(DTO dto) {
         return LineUp.builder()
-                .id(entity.getId())
-                .helpDetail(HelpDetail.toDomain(entity.getHelpEntity()))
-                .progress(Progress.toDomain(entity.getProgressEntity()))
+                .id(dto.getId())
+                .helpDetail(HelpDetail.from(dto))
+                .progress(Progress.from(dto))
                 .build();
+    }
+
+    @Getter
+    public static final class DTO implements HelpDetail.DTO, Progress.DTO {
+        private final Long id;
+        private final Long helpRegisterId;
+        private final String title;
+        private final LocalDateTime start;
+        private final LocalDateTime end;
+        private final String placeId;
+        private final Long reward;
+        private final Progress.ProgressStatus status;
+        private final Optional<Long> helperId;
+        private final Optional<String> photoPath;
+        private final boolean completed;
+
+        @Builder
+        public DTO(Long id, Long helpRegisterId, String title, LocalDateTime start, LocalDateTime end, String placeId, Long reward, Progress.ProgressStatus status, Optional<Long> helperId, Optional<String> photoPath, boolean completed) {
+            // fixme: null 처리
+            this.id = id;
+            this.helpRegisterId = helpRegisterId;
+            this.title = title;
+            this.start = start;
+            this.end = end;
+            this.placeId = placeId;
+            this.reward = reward;
+            this.status = status;
+            this.helperId = helperId;
+            this.photoPath = photoPath;
+            this.completed = completed;
+        }
+
+        public static LineUp.DTO getDTO(LineUp lineUp) {
+            return LineUp.DTO.builder()
+                    .id(lineUp.getId())
+                    .helpRegisterId(lineUp.getHelpDetail().getHelpRegisterId())
+                    .title(lineUp.getHelpDetail().getTitle())
+                    .start(lineUp.getHelpDetail().getStart())
+                    .end(lineUp.getHelpDetail().getEnd())
+                    .placeId(lineUp.getHelpDetail().getPlaceId())
+                    .reward(lineUp.getHelpDetail().getReward())
+                    .status(lineUp.getProgress().getStatus())
+                    .helperId(lineUp.getProgress().getHelperId())
+                    .photoPath(lineUp.getProgress().getPhotoPath())
+                    .completed(lineUp.getProgress().isCompleted())
+                    .build();
+        }
     }
 
 

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/LineUpService.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/domain/model/help/child/LineUpService.java
@@ -2,7 +2,6 @@ package com.example.checkinrequestMS.HelpAPI.domain.model.help.child;
 
 import com.example.checkinrequestMS.HelpAPI.application.service.alarm.AlarmService;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.HelpDetail;
-import com.example.checkinrequestMS.HelpAPI.domain.model.help.Progress;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.stereotype.Service;
@@ -27,14 +26,14 @@ public class LineUpService {
         return lineUpRepository.save(lineUp);
     }
 
-    public LineUpSelected update(LineUpService.Update dto) {
+    public LineUp.DTO update(LineUpService.Update dto) {
         LineUp lineUp = lineUpRepository.findById(dto.getHelpId());
         lineUp.update(dto);
-        return LineUpService.LineUpSelected.createResponse(lineUpRepository.update(lineUp));
+        return LineUp.DTO.getDTO(lineUp);
     }
 
-    public LineUpSelected findLineUp(Long id) {
-        return LineUpSelected.createResponse(lineUpRepository.findById(id));
+    public LineUp.DTO findLineUp(Long id) {
+        return LineUp.DTO.getDTO(lineUpRepository.findById(id));
     }
 
     public Long startLineUp(@NonNull LineUpStarted dto) {
@@ -192,34 +191,6 @@ public class LineUpService {
                     .start(LocalDateTime.now())
                     .option(10)
                     .reward(100L)
-                    .build();
-        }
-    }
-
-    @Getter
-    @NoArgsConstructor(force = true)
-    public static final class LineUpSelected {
-
-        private final Long lineUpId;
-
-        private final HelpDetail.HelpDetailSelected helpDetail;
-
-        private final Progress.ProgressSelected progress;
-
-        @Builder(access = AccessLevel.PRIVATE)
-        public LineUpSelected(@NonNull Long lineUpId,
-                              @NonNull HelpDetail.HelpDetailSelected helpDetail,
-                              @NonNull Progress.ProgressSelected progress) {
-            this.lineUpId = lineUpId;
-            this.helpDetail = helpDetail;
-            this.progress = progress;
-        }
-
-        public static LineUpService.LineUpSelected createResponse(LineUp lineUp) {
-            return LineUpService.LineUpSelected.builder()
-                    .lineUpId(lineUp.getId())
-                    .helpDetail(HelpDetail.HelpDetailSelected.createResponse(lineUp.getHelpDetail()))
-                    .progress(Progress.ProgressSelected.createResponse(lineUp.getProgress()))
                     .build();
         }
     }

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/entity/HelpDetailEntity.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/entity/HelpDetailEntity.java
@@ -1,7 +1,7 @@
 package com.example.checkinrequestMS.HelpAPI.infra.db.entity;
 
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.HelpDetail;
-import jakarta.persistence.*;
+import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,14 +31,18 @@ public class HelpDetailEntity {
         this.reward = reward;
     }
 
-    public static HelpDetailEntity transferFrom(HelpDetail helpDetail) {
+    public static HelpDetailEntity from(HelpDetail.DTO dto) {
         return HelpDetailEntity.builder()
-                .helpRegisterId(helpDetail.getHelpRegisterId())
-                .title(helpDetail.getTitle())
-                .start(helpDetail.getStart())
-                .end(helpDetail.getEnd())
-                .placeId(helpDetail.getPlaceId())
-                .reward(helpDetail.getReward())
+                .helpRegisterId(dto.getHelpRegisterId())
+                .title(dto.getTitle())
+                .start(dto.getStart())
+                .end(dto.getEnd())
+                .placeId(dto.getPlaceId())
+                .reward(dto.getReward())
                 .build();
     }
+    // 1. 인터페이스로 해결하면 DTO가 인프라에 의존하게 된다
+    // 2. 내부 클래스로 해결
+    // 3. 각 메서드 만들기.
+
 }

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/entity/ProgressEntity.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/entity/ProgressEntity.java
@@ -1,7 +1,9 @@
 package com.example.checkinrequestMS.HelpAPI.infra.db.entity;
 
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.Progress;
-import jakarta.persistence.*;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,12 +25,12 @@ public class ProgressEntity {
     @Getter
     private boolean completed;
 
-    public static ProgressEntity transferFrom(Progress progress) {
+    public static ProgressEntity from(Progress.DTO dto) {
         return ProgressEntity.builder()
-                .status(progress.getStatus())
-                .helperId(progress.getHelperId().orElse(null))
-                .photoPath(progress.getPhotoPath().orElse(null))
-                .completed(progress.isCompleted())
+                .status(dto.getStatus())
+                .helperId(dto.getHelperId().orElse(null))
+                .photoPath(dto.getPhotoPath().orElse(null))
+                .completed(dto.isCompleted())
                 .build();
     }
 

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/entity/child/CheckInEntity.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/entity/child/CheckInEntity.java
@@ -25,14 +25,16 @@ public class CheckInEntity {
 
     @Builder(access = AccessLevel.PROTECTED)
     protected CheckInEntity(@NonNull Long id, @NonNull CheckIn checkIn) {
+        CheckIn.DTO dto = CheckIn.DTO.getDTO(checkIn);
         this.id = id;
-        this.helpEntity = HelpDetailEntity.transferFrom(checkIn.getHelpEntityToPersist());
-        this.progressEntity = ProgressEntity.transferFrom(checkIn.getProgressEntityToPersist());
+        this.helpEntity = HelpDetailEntity.from(dto);
+        this.progressEntity = ProgressEntity.from(dto);
     }
 
     protected CheckInEntity(CheckIn checkIn, Boolean isRegister) {
-        this.helpEntity = HelpDetailEntity.transferFrom(checkIn.getHelpDetail());
-        this.progressEntity = ProgressEntity.transferFrom(checkIn.getProgress());
+        CheckIn.DTO dto = CheckIn.DTO.getDTO(checkIn);
+        this.helpEntity = HelpDetailEntity.from(dto);
+        this.progressEntity = ProgressEntity.from(dto);
     }
 
     public static CheckInEntity register(CheckIn checkIn) {
@@ -40,11 +42,27 @@ public class CheckInEntity {
     }
 
     public CheckIn update(CheckIn checkIn) {
-        this.helpEntity = HelpDetailEntity.transferFrom(checkIn.getHelpDetail());
-        return CheckIn.transferFrom(this);
+        this.helpEntity = HelpDetailEntity.from(CheckIn.DTO.getDTO(checkIn));
+        return returnDomainEntity();
     }
 
-    public static CheckInEntity transferFrom(CheckIn checkIn) {
+    public CheckIn returnDomainEntity() {
+        CheckIn.DTO dto = CheckIn.DTO.builder()
+                .id(this.getId())
+                .helpRegisterId(this.getHelpEntity().getHelpRegisterId())
+                .title(this.getHelpEntity().getTitle())
+                .start(this.getHelpEntity().getStart())
+                .end(this.getHelpEntity().getEnd())
+                .placeId(this.getHelpEntity().getPlaceId())
+                .reward(this.getHelpEntity().getReward())
+                .helperId(this.getProgressEntity().getHelperId())
+                .photoPath(this.getProgressEntity().getPhotoPath())
+                .completed(this.getProgressEntity().isCompleted())
+                .build();
+        return CheckIn.from(dto);
+    }
+
+    public static CheckInEntity from(CheckIn checkIn) {
         return CheckInEntity.builder()
                 .id(checkIn.getId())
                 .checkIn(checkIn)

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/entity/child/EtcEntity.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/entity/child/EtcEntity.java
@@ -27,16 +27,18 @@ public class EtcEntity {
 
     @Builder(access = AccessLevel.PROTECTED)
     protected EtcEntity(@NonNull Long id, @NonNull Etc etc) {
+        Etc.DTO dto = Etc.DTO.getDTO(etc);
         this.id = id;
         this.contents = etc.getContents();
-        this.helpEntity = HelpDetailEntity.transferFrom(etc.getHelpDetail());
-        this.progressEntity = ProgressEntity.transferFrom(etc.getProgress());
+        this.helpEntity = HelpDetailEntity.from(dto);
+        this.progressEntity = ProgressEntity.from(dto);
     }
 
     protected EtcEntity(Etc etc, boolean isRegister) {
+        Etc.DTO dto = Etc.DTO.getDTO(etc);
         this.contents = etc.getContents();
-        this.helpEntity = HelpDetailEntity.transferFrom(etc.getHelpDetail());
-        this.progressEntity = ProgressEntity.transferFrom(etc.getProgress());
+        this.helpEntity = HelpDetailEntity.from(dto);
+        this.progressEntity = ProgressEntity.from(dto);
     }
 
     //Business
@@ -46,11 +48,27 @@ public class EtcEntity {
 
     public Etc update(Etc etc) {
         this.contents = etc.getContents();
-        this.helpEntity = HelpDetailEntity.transferFrom(etc.getHelpDetail());
-        return Etc.transferFrom(this);
+        this.helpEntity = HelpDetailEntity.from(Etc.DTO.getDTO(etc));
+        return returnDomainEntity();
     }
 
-    public static EtcEntity transferFrom(Etc etc) {
+    public Etc returnDomainEntity() {
+        Etc.DTO dto = Etc.DTO.builder()
+                .id(this.getId())
+                .helpRegisterId(this.getHelpEntity().getHelpRegisterId())
+                .title(this.getHelpEntity().getTitle())
+                .start(this.getHelpEntity().getStart())
+                .end(this.getHelpEntity().getEnd())
+                .placeId(this.getHelpEntity().getPlaceId())
+                .reward(this.getHelpEntity().getReward())
+                .helperId(this.getProgressEntity().getHelperId())
+                .photoPath(this.getProgressEntity().getPhotoPath())
+                .contents(this.getContents())
+                .build();
+        return Etc.from(dto);
+    }
+
+    public static EtcEntity from(Etc etc) {
         return EtcEntity.builder()
                 .id(etc.getId())
                 .etc(etc)

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/entity/child/LineUpEntity.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/entity/child/LineUpEntity.java
@@ -25,14 +25,16 @@ public class LineUpEntity {
 
     @Builder(access = AccessLevel.PROTECTED)
     protected LineUpEntity(@NonNull Long id, @NonNull LineUp lineUp) {
+        LineUp.DTO dto = LineUp.DTO.getDTO(lineUp);
         this.id = id;
-        this.helpEntity = HelpDetailEntity.transferFrom(lineUp.getHelpDetail());
-        this.progressEntity = ProgressEntity.transferFrom(lineUp.getProgress());
+        this.helpEntity = HelpDetailEntity.from(dto);
+        this.progressEntity = ProgressEntity.from(dto);
     }
 
     protected LineUpEntity(LineUp lineUp, Boolean isRegister) {
-        this.helpEntity = HelpDetailEntity.transferFrom(lineUp.getHelpDetail());
-        this.progressEntity = ProgressEntity.transferFrom(lineUp.getProgress());
+        LineUp.DTO dto = LineUp.DTO.getDTO(lineUp);
+        this.helpEntity = HelpDetailEntity.from(dto);
+        this.progressEntity = ProgressEntity.from(dto);
     }
 
     //Business
@@ -41,11 +43,27 @@ public class LineUpEntity {
     }
 
     public LineUp update(LineUp lineUp) {
-        this.helpEntity = HelpDetailEntity.transferFrom(lineUp.getHelpDetail());
-        return LineUp.transferFrom(this);
+        this.helpEntity = HelpDetailEntity.from(LineUp.DTO.getDTO(lineUp));
+        return returnDomainEntity();
     }
 
-    public static LineUpEntity transferFrom(LineUp lineUp) {
+    public LineUp returnDomainEntity() {
+        LineUp.DTO dto = LineUp.DTO.builder()
+                .id(this.getId())
+                .helpRegisterId(this.getHelpEntity().getHelpRegisterId())
+                .title(this.getHelpEntity().getTitle())
+                .start(this.getHelpEntity().getStart())
+                .end(this.getHelpEntity().getEnd())
+                .placeId(this.getHelpEntity().getPlaceId())
+                .reward(this.getHelpEntity().getReward())
+                .helperId(this.getProgressEntity().getHelperId())
+                .photoPath(this.getProgressEntity().getPhotoPath())
+                .completed(this.getProgressEntity().isCompleted())
+                .build();
+        return LineUp.from(dto);
+    }
+
+    public static LineUpEntity from(LineUp lineUp) {
         return LineUpEntity.builder()
                 .id(lineUp.getId())
                 .lineUp(lineUp)

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/help/CheckInJPARepository.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/help/CheckInJPARepository.java
@@ -1,9 +1,9 @@
 package com.example.checkinrequestMS.HelpAPI.infra.db.help;
 
-import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.CheckInRepository;
 import com.example.checkinrequestMS.HelpAPI.domain.exceptions.help.HelpErrorCode;
 import com.example.checkinrequestMS.HelpAPI.domain.exceptions.help.HelpException;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.CheckIn;
+import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.CheckInRepository;
 import com.example.checkinrequestMS.HelpAPI.infra.db.entity.child.CheckInEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -21,8 +21,9 @@ public class CheckInJPARepository implements CheckInRepository {
 
     @Override
     public CheckIn findById(Long id) {
-        return CheckIn.transferFrom(checkInSpringJPARepository.findById(id)
-                .orElseThrow(() -> new HelpException(HelpErrorCode.NO_HELP_INFO)));
+        CheckInEntity checkInEntity = checkInSpringJPARepository.findById(id)
+                .orElseThrow(() -> new HelpException(HelpErrorCode.NO_HELP_INFO));
+        return checkInEntity.returnDomainEntity();
     }
 
     @Override

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/help/EtcJPARepository.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/help/EtcJPARepository.java
@@ -21,8 +21,9 @@ public class EtcJPARepository implements EtcRepository {
 
     @Override
     public Etc findById(Long id) {
-        return Etc.transferFrom(etcSpringJPARepository.findById(id)
-                .orElseThrow(() -> new HelpException(HelpErrorCode.NO_HELP_INFO)));
+        EtcEntity entity = etcSpringJPARepository.findById(id)
+                .orElseThrow(() -> new HelpException(HelpErrorCode.NO_HELP_INFO));
+        return entity.returnDomainEntity();
     }
 
     @Override

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/help/LineUpJPARepository.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/infra/db/help/LineUpJPARepository.java
@@ -21,8 +21,9 @@ public class LineUpJPARepository implements LineUpRepository {
 
     @Override
     public LineUp findById(Long id) {
-        return LineUp.transferFrom(lineUpSpringJPARepository.findById(id)
-                .orElseThrow(() -> new HelpException(HelpErrorCode.NO_HELP_INFO)));
+        LineUpEntity entity = lineUpSpringJPARepository.findById(id)
+                .orElseThrow(() -> new HelpException(HelpErrorCode.NO_HELP_INFO));
+        return entity.returnDomainEntity();
     }
 
     @Override

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/read/HelpSelectController.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/read/HelpSelectController.java
@@ -1,9 +1,7 @@
 package com.example.checkinrequestMS.HelpAPI.web.controller.help.read;
 
 import com.example.checkinrequestMS.HelpAPI.application.service.help.read.HelpSelectApplication;
-import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.CheckInService;
-import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.EtcService;
-import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.LineUpService;
+import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.*;
 import com.example.checkinrequestMS.HelpAPI.web.controller.help.write.URIRULE;
 import lombok.*;
 import org.springframework.http.ResponseEntity;
@@ -20,17 +18,17 @@ public class HelpSelectController {
     private final HelpSelectApplication helpSelectApplication;
 
     @GetMapping(URIRULE.CHECK_INS + "{id}")
-    public ResponseEntity<CheckInService.CheckInSelected> selectCheckIn(@PathVariable Long id) {
+    public ResponseEntity<CheckIn.DTO> selectCheckIn(@PathVariable Long id) {
         return ResponseEntity.ok(helpSelectApplication.selectCheckIn(id));
     }
 
     @GetMapping(URIRULE.LINE_UPS + "{id}")
-    public ResponseEntity<LineUpService.LineUpSelected> selectLineUp(@PathVariable Long id) {
+    public ResponseEntity<LineUp.DTO> selectLineUp(@PathVariable Long id) {
         return ResponseEntity.ok(helpSelectApplication.selectLineUp(id));
     }
 
     @GetMapping(URIRULE.ETCS + "{id}")
-    public ResponseEntity<EtcService.EtcSelected> selectEtc(@PathVariable Long id) {
+    public ResponseEntity<Etc.DTO> selectEtc(@PathVariable Long id) {
         return ResponseEntity.ok(helpSelectApplication.selectEtc(id));
     }
 }

--- a/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/write/HelpWriteController.java
+++ b/check-in-request-MS/src/main/java/com/example/checkinrequestMS/HelpAPI/web/controller/help/write/HelpWriteController.java
@@ -3,6 +3,7 @@ package com.example.checkinrequestMS.HelpAPI.web.controller.help.write;
 import com.example.checkinrequestMS.HelpAPI.application.service.help.write.CheckInWriteApplication;
 import com.example.checkinrequestMS.HelpAPI.application.service.help.write.EtcWriteApplication;
 import com.example.checkinrequestMS.HelpAPI.application.service.help.write.LineUpWriteApplication;
+import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.CheckIn;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.CheckInService;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.EtcService;
 import com.example.checkinrequestMS.HelpAPI.domain.model.help.child.LineUpService;
@@ -40,8 +41,8 @@ public class HelpWriteController {
     }
 
     @PutMapping(URIRULE.CHECK_INS + "/{id}")
-    public ResponseEntity<DefaultHTTPResponse<CheckInService.CheckInSelected>> updateCheckIn(@PathVariable Long id, @Validated @RequestBody CheckInService.Update request) {
-        return ResponseEntity.ok(new DefaultHTTPResponse<CheckInService.CheckInSelected>(CHECK_IN_UPDATE_SUCCESS, checkInWriteApplication.updateCheckIn(request)));
+    public ResponseEntity<DefaultHTTPResponse<CheckIn.DTO>> updateCheckIn(@PathVariable Long id, @Validated @RequestBody CheckInService.Update request) {
+        return ResponseEntity.ok(new DefaultHTTPResponse<CheckIn.DTO>(CHECK_IN_UPDATE_SUCCESS, checkInWriteApplication.updateCheckIn(request)));
     }
 
     @PostMapping(URIRULE.LINE_UPS)


### PR DESCRIPTION
인프라와 도메인간의 의존성을 분리하여 JPA엔티티를 도메인레이어에서 분리했으나 매핑 과정에서 도메인의 객체를 인프라의 JPA 엔티티 객체로 매핑하는 코드로 인해 의존성이 남아 있었습니다.

이를 DTO를 통해 분리하였습니다.

체크인 관련 코드에 메인 변경 사항들을 담았습니다.