### PR TITLE
feat/70 file upload chunk front

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+
 ### STS ###
 .apt_generated
 .classpath
@@ -35,3 +36,14 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### SQL 설정 ###
+*.cnf
+
+### ENV 파일 ###
+*.env
+
+### NPM ###
+*.json
+node_modules/
+

--- a/front-server/src/main/java/com/frontServer/ConfigController.java
+++ b/front-server/src/main/java/com/frontServer/ConfigController.java
@@ -1,4 +1,4 @@
-package com.littleSNSMS;
+package com.frontServer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/front-server/src/main/java/com/frontServer/FileController.java
+++ b/front-server/src/main/java/com/frontServer/FileController.java
@@ -1,0 +1,38 @@
+package com.frontServer;
+
+import com.frontServer.infra.FileChunkUploader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Controller
+@CrossOrigin(origins = "*")
+public class FileController {
+
+//    @Autowired
+//    private FileChunkUploader fileChunkUploader;
+
+    @GetMapping("/upload")
+    public String uploadForm() {
+        return "upload";
+    }
+//
+//    @PostMapping("/upload/chunk")
+//    public ResponseEntity<String> uploadChunk(
+//            @RequestParam("file") MultipartFile chunk,
+//            @RequestParam("chunkNumber") int chunkNumber,
+//            @RequestParam("totalChunks") int totalChunks,
+//            @RequestParam("filename") String filename) throws IOException {
+//
+//        return fileChunkUploader.chunkUpload(chunk, chunkNumber, totalChunks, filename)
+//                ? ResponseEntity.ok().body("Upload completed")
+//                : ResponseEntity.status(HttpStatus.PARTIAL_CONTENT).body("Chunk uploaded");
+//    }
+
+
+}

--- a/front-server/src/main/java/com/frontServer/FireBaseDTO.java
+++ b/front-server/src/main/java/com/frontServer/FireBaseDTO.java
@@ -1,4 +1,4 @@
-package com.littleSNSMS;
+package com.frontServer;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/front-server/src/main/java/com/frontServer/FrontServerMain.java
+++ b/front-server/src/main/java/com/frontServer/FrontServerMain.java
@@ -1,4 +1,4 @@
-package com.littleSNSMS;
+package com.frontServer;
 
 
 import org.springframework.boot.SpringApplication;

--- a/front-server/src/main/resources/application.yml
+++ b/front-server/src/main/resources/application.yml
@@ -1,5 +1,9 @@
 server:
   port: 8086
 spring:
+  servlet:
+    multipart:
+      max-file-size: 10GB
+      max-request-size: 500MB
   config:
     import: classpath:Firebase.env[.properties]

--- a/front-server/src/main/resources/static/js/file/fileUploadSequential.js
+++ b/front-server/src/main/resources/static/js/file/fileUploadSequential.js
@@ -1,5 +1,20 @@
+document.getElementById('uploadButton').addEventListener('click', () => {
+    const file = document.getElementById('fileInput').files[0];
+    if (file) {
+        uploadFile(file);
+    } else {
+        alert('파일을 선택해 주세요.');
+    }
+});
+
 const uploadFile = (file) => {
-    const chunkSize = 1024 * 1024; // 1MB
+
+    if (!file) {
+        alert('파일을 선택해 주세요.');
+        return;
+    }
+
+    const chunkSize = 200 * 1024 * 1024;
     const totalChunks = Math.ceil(file.size / chunkSize);
     let currentChunk = 0;
 
@@ -14,6 +29,7 @@ const uploadFile = (file) => {
         formData.append("totalChunks", totalChunks);
         formData.append("filename", file.name);
 
+        //fixme: 성능 향상위한 부분 재전송 로직 추가하기.
         fetch("http://localhost:8086/upload/chunk", {
             method: "POST",
             body: formData
@@ -35,4 +51,6 @@ const uploadFile = (file) => {
 
     sendNextChunk();
 };
-module.exports = {uploadFile};
+
+//check: module 있으면 node.js 로직으로 인식해서 import가 불가. -> 추후 공존 법 모색.
+//module.exports = {uploadFile};

--- a/front-server/src/main/resources/static/js/file/fileUploadSequential.js
+++ b/front-server/src/main/resources/static/js/file/fileUploadSequential.js
@@ -1,0 +1,38 @@
+const uploadFile = (file) => {
+    const chunkSize = 1024 * 1024; // 1MB
+    const totalChunks = Math.ceil(file.size / chunkSize);
+    let currentChunk = 0;
+
+    const sendNextChunk = () => {
+        const start = currentChunk * chunkSize;
+        const end = Math.min(start + chunkSize, file.size);
+        const chunk = file.slice(start, end);
+
+        const formData = new FormData();
+        formData.append("file", chunk);
+        formData.append("chunkNumber", currentChunk);
+        formData.append("totalChunks", totalChunks);
+        formData.append("filename", file.name);
+
+        fetch("http://localhost:8086/upload/chunk", {
+            method: "POST",
+            body: formData
+        })
+            .then(response => {
+                if (response.status === 206) {
+                    currentChunk++;
+                    if (currentChunk < totalChunks) {
+                        sendNextChunk();
+                    }
+                } else if (response.status === 200) {
+                    console.log("Upload completed");
+                }
+            })
+            .catch(error => {
+                console.error("Upload failed:", error);
+            });
+    };
+
+    sendNextChunk();
+};
+module.exports = {uploadFile};

--- a/front-server/src/main/resources/templates/upload.html
+++ b/front-server/src/main/resources/templates/upload.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <script type="module" th:src="@{js/file/fileUploadSequential.js}"></script>
+    <title>File Upload Test</title>
+    <style>
+        .upload-container {
+            margin: 20px;
+            padding: 20px;
+            border: 2px dashed #ccc;
+            border-radius: 10px;
+        }
+
+        .progress-bar {
+            width: 100%;
+            height: 20px;
+            background-color: #f0f0f0;
+            border-radius: 5px;
+            margin-top: 10px;
+        }
+
+        .progress {
+            width: 0%;
+            height: 100%;
+            background-color: #4CAF50;
+            border-radius: 5px;
+            transition: width 0.3s;
+        }
+    </style>
+</head>
+<body>
+<div class="upload-container">
+    <h2>File Upload</h2>
+    <input type="file" id="fileInput">
+    <button id="uploadButton">Upload</button>
+    <div id="fileInfo"></div>
+    <div class="progress-bar">
+        <div class="progress" id="progressBar"></div>
+    </div>
+</div>
+<script>
+    document.getElementById('fileInput').addEventListener('change', (e) => {
+        const file = e.target.files[0];
+        if (file) {
+            const sizeInGB = (file.size / (1024 * 1024 * 1024)).toFixed(2);
+            const info = `
+                파일명: ${file.name}<br>
+                크기: ${sizeInGB} GB<br>
+                타입: ${file.type}
+                `;
+            document.getElementById('fileInfo').innerHTML = info;
+        }
+    });
+
+</script>

--- a/front-server/src/test/java/com/frontServer/ConfigControllerTest.java
+++ b/front-server/src/test/java/com/frontServer/ConfigControllerTest.java
@@ -1,10 +1,9 @@
-package com.littleSNSMS;
+package com.frontServer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;

--- a/front-server/src/test/javascript/file.integrated.test.js
+++ b/front-server/src/test/javascript/file.integrated.test.js
@@ -1,0 +1,25 @@
+const {uploadFile} = require('@/file/fileUploadSequential');
+const fs = require('fs');
+
+describe('File Upload Tests', () => {
+    test('should upload file to real server', async () => {
+
+        const path = require('path');
+        const filePath = path.join(__dirname, 'test-files', 'test.m4v');
+        const fileBuffer = fs.readFileSync(filePath);
+        const mockFile = new Blob([fileBuffer], {
+            type: 'video/x-m4v'  // M4V 파일의 MIME 타입
+        });
+        mockFile.name = 'test.m4v';
+
+        try {
+            const result = await uploadFile(mockFile);
+            console.log('Upload successful');
+            console.log('Upload result:', result);
+
+            expect(result).toBeDefined();
+        } catch (error) {
+            console.error('Upload failed:', error);
+        }
+    }, 30000);
+});

--- a/front-server/src/test/javascript/file.test.js
+++ b/front-server/src/test/javascript/file.test.js
@@ -1,0 +1,37 @@
+const {uploadFile} = require('@/file/fileUploadSequential');
+const {uploadFileParallel} = require('@/file/fileUploadParallel');
+
+describe('File Upload Tests', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn();
+        global.FormData = jest.fn(() => ({
+            append: jest.fn()
+        }));
+        global.Blob = jest.fn(() => ({}));
+    });
+
+    test('should upload file in chunks', async () => {
+        const mockFile = {
+            size: 3 * 1024 * 1024, // 3MB
+            name: 'test.txt',
+            slice: jest.fn((start, end) => new Blob(['chunk']))
+        };
+
+        global.fetch.mockImplementation(() =>
+            Promise.resolve({
+                status: 206,
+                ok: true
+            })
+        );
+
+        await uploadFile(mockFile);
+        await new Promise(process.nextTick);
+
+        const expectedChunks = Math.ceil(mockFile.size / (1024 * 1024));
+        expect(fetch).toHaveBeenCalledTimes(expectedChunks);
+        console.log('Expected chunks:', expectedChunks);
+        console.log('Actual fetch calls:', fetch.mock.calls.length);
+        console.log('Fetch calls:', fetch.mock.calls);
+    });
+});
+


### PR DESCRIPTION
### Updated

- 파일 업로드 분할순차전송
  - Javascript 코드. 테스트시 npm init 및 jest 설치 필요
  - 백엔드 부분과 병렬전송도 작성 중. (진행 중)
- src 상위 디렉토리 이름 변경(frontServer)